### PR TITLE
Fix Infinite loop when Airport has no STARS

### DIFF
--- a/DataConverter.cpp
+++ b/DataConverter.cpp
@@ -147,7 +147,7 @@ namespace Internal
 		int ApId = GetAPIndex(ICAO);
 		while(fscanf(fp, "%s", word) != EOF)
 		{
-			if(Bravo::StringEquals("SID", word))
+  			if(Bravo::StringEquals("SIDS", word))
 			{
 				SID_LABEL:
 				while(fscanf(fp, "%s", word))
@@ -165,6 +165,10 @@ namespace Internal
 						if(depFix.find(fix) == depFix.end())
 							depFix[fix] = GetDAIndex(ApId, fix);
 						goto STAR_LABEL;
+					}
+					else if (Bravo::StringEquals("ENDSIDS", word)) 
+					{
+						break;
 					}
 				}
 				if(depFix.find(fix) == depFix.end())


### PR DESCRIPTION
It caught my attention that it entered an infinite loop when trying to calculate a route from an airport which has no Standard arrival procedure.
After gdb attached I found it loop in the word "ENDAPPROACHES" without checking the EOF of fp or a fail-safe way to exit the SID searching loop.
This commit shall act as one of the ways to exit the SID searching if the ENDSIDS is found.