### PR TITLE
feat: DFD SQLite loaders (v1/v2) + navdata subdirs, v3.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 project(BravoFinder
-        VERSION 3.6.2
+        VERSION 3.7.0
         DESCRIPTION "A realistic / compliant flight route engine"
         LANGUAGES C CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.21)
 project(BravoFinder
         VERSION 3.6.2
         DESCRIPTION "A realistic / compliant flight route engine"
-        LANGUAGES CXX)
+        LANGUAGES C CXX)
 
 # ---------------------------------------------------------------------------
 # Global settings
@@ -62,6 +62,31 @@ if(BRAVOFINDER_BUILD_TESTS)
   # Make Catch2's CTest integration module (Catch.cmake) available.
   list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 endif()
+
+# SQLite amalgamation (read-only, used by the DFD loaders). A single ~9 MB C
+# translation unit, compiled once into its own static lib so (a) it is not
+# recompiled when consumers change and (b) its third-party C warnings can be
+# silenced without polluting the project's -Werror. Pin a specific version via
+# URL_HASH; bumping SQLite means updating URL + hash together.
+FetchContent_Declare(
+  sqlite3
+  URL https://www.sqlite.org/2024/sqlite-amalgamation-3460000.zip
+  URL_HASH SHA256=712a7d09d2a22652fb06a49af516e051979a3984adb067da86760e60ed51a7f5)
+FetchContent_MakeAvailable(sqlite3)
+
+set(_sqlite3_dir ${sqlite3_SOURCE_DIR})
+add_library(bf_sqlite3 STATIC ${_sqlite3_dir}/sqlite3.c)
+target_include_directories(bf_sqlite3 PUBLIC ${_sqlite3_dir})
+# Load extension is never used; threadsafe=1 (serialized default) plus per-
+# connection SQLITE_OPEN_NOMUTEX (thread_local connections, never shared across
+# threads) gives correct, lock-free reads.
+target_compile_definitions(bf_sqlite3 PRIVATE
+                           SQLITE_OMIT_LOAD_EXTENSION
+                           SQLITE_THREADSAFE=1)
+# Third-party C: silence every warning so it never trips -Werror.
+target_compile_options(bf_sqlite3 PRIVATE
+                       $<$<OR:$<C_COMPILER_ID:GNU>,$<C_COMPILER_ID:Clang>>:-w>)
+add_library(bf::sqlite3 ALIAS bf_sqlite3)
 
 # ---------------------------------------------------------------------------
 # Subdirectories

--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ full tool reference, argument semantics, and client configuration.
 # detail, so deployment needs only that file, not the CIFP/ directory.
 bf build navdata                    # writes navdata/nav_<cycle>.bfdb
 bf build /path/to/xplane -o my.bfdb # explicit name: writes my.bfdb
-bf build navdata --without-cifp     # omit the CIFP procedure section
 bf build navdata --loader xplane12  # select source loader (default; only one today)
 
 # Find a route (reads navigation data from ./navdata by default)

--- a/apps/cli/cli_common.cc
+++ b/apps/cli/cli_common.cc
@@ -99,7 +99,9 @@ void PrintRoutesJson(const std::vector<Route>& routes) {
 std::optional<FlRange> ParseAltSpec(const std::string& spec) {
   const size_t dash = spec.find('-');
   auto to_int = [](const std::string& s, int& out) -> bool {
-    if (s.empty()) return false;
+    if (s.empty()) {
+      return false;
+    }
     try {
       size_t pos = 0;
       out = std::stoi(s, &pos);
@@ -110,7 +112,9 @@ std::optional<FlRange> ParseAltSpec(const std::string& spec) {
   };
   if (dash == std::string::npos) {
     int fl = 0;
-    if (!to_int(spec, fl)) return std::nullopt;
+    if (!to_int(spec, fl)) {
+      return std::nullopt;
+    }
     return FlRange{fl, fl};
   }
   int lo = 0;
@@ -118,7 +122,9 @@ std::optional<FlRange> ParseAltSpec(const std::string& spec) {
   if (!to_int(spec.substr(0, dash), lo) || !to_int(spec.substr(dash + 1), hi)) {
     return std::nullopt;
   }
-  if (lo > hi) return std::nullopt;
+  if (lo > hi) {
+    return std::nullopt;
+  }
   return FlRange{lo, hi};
 }
 

--- a/apps/cli/cmd_build.cc
+++ b/apps/cli/cmd_build.cc
@@ -14,19 +14,16 @@ void RegisterBuild(CLI::App& app, int& exit_code) {
     std::string data_dir;
     std::string output;
     std::string loader = "xplane12";
-    bool without_cifp = false;
   };
   auto args = std::make_shared<Args>();
 
-  CLI::App* build = app.add_subcommand("build", "Build a .bfdb cache from X-Plane data");
-  build->add_option("data_dir", args->data_dir, "Directory of X-Plane navigation data")->required();
+  CLI::App* build = app.add_subcommand("build", "Build a .bfdb cache from navigation data");
+  build->add_option("data_dir", args->data_dir, "Directory of navigation data")->required();
   build->add_option("-o,--output", args->output,
                     "Output .bfdb path (default: <data_dir>/nav_<cycle>.bfdb)");
   build->add_option("--loader", args->loader, "Data source loader")
       ->capture_default_str()
-      ->check(CLI::IsMember({"xplane12"}));
-  build->add_flag("--without-cifp", args->without_cifp,
-                  "Omit the CIFP procedure section from the .bfdb");
+      ->check(CLI::IsMember({"dfd1", "dfd2", "xplane12"}));
 
   build->callback([args, &exit_code]() {
     Result<NavDatabase> db = NavDatabase::Open(args->data_dir, args->loader);
@@ -42,8 +39,9 @@ void RegisterBuild(CLI::App& app, int& exit_code) {
                                 ? args->data_dir + "/" + FormatBfdbName(db.value().cycle())
                                 : args->output;
     // One unified file holds the graph, the CIFP procedures, and the navaid
-    // detail. --without-cifp omits the CIFP section (smaller file, no procedures).
-    Result<uint32_t> written = db.value().WriteUnified(out, !args->without_cifp);
+    // detail. The CIFP section is always written (a cache without procedures
+    // cannot resolve SID/STAR).
+    Result<uint32_t> written = db.value().WriteUnified(out);
     if (!written) {
       std::cerr << "error: " << written.error().message << "\n";
       exit_code = EXIT_FAILURE;

--- a/bench/variants/memoize/core/graph/yen_kshortest.cc
+++ b/bench/variants/memoize/core/graph/yen_kshortest.cc
@@ -297,8 +297,8 @@ std::vector<ShortestPath> FindKShortestPathsMulti(const NavGraph& graph,
       // Single-source (the spur node) -> any goal. The spur node's own seed is
       // irrelevant here; CostOfPathMulti re-applies the true source seed from the
       // stitched path's first vertex.
-      const ShortestPath spur = FindShortestPathMulti(
-          graph, {SeededEndpoint{spur_node, 0.0}}, goals, spur_opts, heuristic);
+      const ShortestPath spur = FindShortestPathMulti(graph, {SeededEndpoint{spur_node, 0.0}},
+                                                      goals, spur_opts, heuristic);
       add_candidate(root, spur);
     }
 

--- a/core/constraints/altitude_constraints.h
+++ b/core/constraints/altitude_constraints.h
@@ -42,6 +42,11 @@ class LevelPreferenceConstraint : public Constraint {
     if (request.level == LevelPreference::kNone) {
       return EdgeVerdict::Allow();
     }
+    // A both-level segment (DFD flightlevel 'B') is usable at either level, so it
+    // is never penalized regardless of the preference.
+    if (EdgeIsBoth(ctx.edge)) {
+      return EdgeVerdict::Allow();
+    }
     const bool wants_high = request.level == LevelPreference::kHigh;
     if (EdgeIsHigh(ctx.edge) == wants_high) {
       return EdgeVerdict::Allow();

--- a/core/domain/airway.h
+++ b/core/domain/airway.h
@@ -1,11 +1,12 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 namespace bf {
 
 // Direction in which an airway segment may be flown, as encoded in
-// earth_awy.dat column 7.
+// earth_awy.dat column 7 (or DFD `direction_restriction`).
 enum class AirwayDirection {
   kBoth,     // 'N' - no restriction, usable in either direction
   kForward,  // 'F' - usable only from -> to
@@ -13,10 +14,12 @@ enum class AirwayDirection {
 };
 
 // Whether a segment belongs to the low (Victor) or high (Jet) airway structure,
-// from earth_awy.dat column 8.
+// or both. X-Plane `earth_awy.dat` uses integer 1/2; DFD `flightlevel` uses
+// 'L'/'H'/'B' (实测 'B'≈1/3, must be honored -- see DFD loader plan).
 enum class AirwayLevel {
-  kLow,  // '1'
-  kHigh  // '2'
+  kLow,   // '1' / 'L'
+  kHigh,  // '2' / 'H'
+  kBoth,  // 'B' - usable at both low and high (DFD only; X-Plane has no both)
 };
 
 // A single airway segment connecting two adjacent waypoints. One named airway
@@ -29,5 +32,31 @@ struct AirwaySegment {
   int base_fl = 0;  // lowest usable flight level (column 9)
   int top_fl = 0;   // highest usable flight level (column 10)
 };
+
+// Parse an airway direction token ('F'/'B'/blank) from earth_awy.dat or DFD.
+// Blank or any unrecognized value means no restriction (kBoth). Shared so X-Plane
+// and the DFD loaders agree on the mapping.
+inline AirwayDirection ParseDirection(std::string_view token) {
+  if (token == "F") {
+    return AirwayDirection::kForward;
+  }
+  if (token == "B") {
+    return AirwayDirection::kBackward;
+  }
+  return AirwayDirection::kBoth;  // 'N' or blank
+}
+
+// Parse an airway level token. Accepts X-Plane's '1'/'2' (as text) and DFD's
+// 'L'/'H'/'B'. Used by the DFD loaders; X-Plane reads its integer hilo column
+// directly. 'B' (both) maps to kBoth so it is never penalized by level filtering.
+inline AirwayLevel ParseAirwayLevel(std::string_view token) {
+  if (token == "2" || token == "H") {
+    return AirwayLevel::kHigh;
+  }
+  if (token == "B") {
+    return AirwayLevel::kBoth;
+  }
+  return AirwayLevel::kLow;  // '1' or 'L'
+}
 
 }  // namespace bf

--- a/core/domain/procedure.cc
+++ b/core/domain/procedure.cc
@@ -16,6 +16,26 @@ bool TerminatesAtFix(PathTerminator t) {
   }
 }
 
+AltitudeConstraint ParseAltConstraint(std::string_view desc, int alt1, int alt2) {
+  AltitudeConstraint ac;
+  if (desc == "+") {
+    ac.kind = AltConstraintKind::kAtOrAbove;
+    ac.alt1_ft = alt1;
+  } else if (desc == "-") {
+    ac.kind = AltConstraintKind::kAtOrBelow;
+    ac.alt1_ft = alt1;
+  } else if (desc == "B") {
+    ac.kind = AltConstraintKind::kBetween;
+    ac.alt1_ft = alt1;  // upper
+    ac.alt2_ft = alt2;  // lower
+  } else if (alt1 != 0) {
+    // '@' or blank descriptor with an altitude present means "cross at".
+    ac.kind = AltConstraintKind::kAt;
+    ac.alt1_ft = alt1;
+  }
+  return ac;
+}
+
 PathTerminator ParsePathTerminator(std::string_view token) {
   if (token == "TF") return PathTerminator::kTF;
   if (token == "IF") return PathTerminator::kIF;

--- a/core/domain/procedure.cc
+++ b/core/domain/procedure.cc
@@ -37,29 +37,75 @@ AltitudeConstraint ParseAltConstraint(std::string_view desc, int alt1, int alt2)
 }
 
 PathTerminator ParsePathTerminator(std::string_view token) {
-  if (token == "TF") return PathTerminator::kTF;
-  if (token == "IF") return PathTerminator::kIF;
-  if (token == "DF") return PathTerminator::kDF;
-  if (token == "CF") return PathTerminator::kCF;
-  if (token == "AF") return PathTerminator::kAF;
-  if (token == "RF") return PathTerminator::kRF;
-  if (token == "CA") return PathTerminator::kCA;
-  if (token == "FA") return PathTerminator::kFA;
-  if (token == "VA") return PathTerminator::kVA;
-  if (token == "HA") return PathTerminator::kHA;
-  if (token == "CD") return PathTerminator::kCD;
-  if (token == "FD") return PathTerminator::kFD;
-  if (token == "VD") return PathTerminator::kVD;
-  if (token == "CI") return PathTerminator::kCI;
-  if (token == "VI") return PathTerminator::kVI;
-  if (token == "CR") return PathTerminator::kCR;
-  if (token == "VR") return PathTerminator::kVR;
-  if (token == "FC") return PathTerminator::kFC;
-  if (token == "FM") return PathTerminator::kFM;
-  if (token == "VM") return PathTerminator::kVM;
-  if (token == "PI") return PathTerminator::kPI;
-  if (token == "HM") return PathTerminator::kHM;
-  if (token == "HF") return PathTerminator::kHF;
+  if (token == "TF") {
+    return PathTerminator::kTF;
+  }
+  if (token == "IF") {
+    return PathTerminator::kIF;
+  }
+  if (token == "DF") {
+    return PathTerminator::kDF;
+  }
+  if (token == "CF") {
+    return PathTerminator::kCF;
+  }
+  if (token == "AF") {
+    return PathTerminator::kAF;
+  }
+  if (token == "RF") {
+    return PathTerminator::kRF;
+  }
+  if (token == "CA") {
+    return PathTerminator::kCA;
+  }
+  if (token == "FA") {
+    return PathTerminator::kFA;
+  }
+  if (token == "VA") {
+    return PathTerminator::kVA;
+  }
+  if (token == "HA") {
+    return PathTerminator::kHA;
+  }
+  if (token == "CD") {
+    return PathTerminator::kCD;
+  }
+  if (token == "FD") {
+    return PathTerminator::kFD;
+  }
+  if (token == "VD") {
+    return PathTerminator::kVD;
+  }
+  if (token == "CI") {
+    return PathTerminator::kCI;
+  }
+  if (token == "VI") {
+    return PathTerminator::kVI;
+  }
+  if (token == "CR") {
+    return PathTerminator::kCR;
+  }
+  if (token == "VR") {
+    return PathTerminator::kVR;
+  }
+  if (token == "FC") {
+    return PathTerminator::kFC;
+  }
+  if (token == "FM") {
+    return PathTerminator::kFM;
+  }
+  if (token == "VM") {
+    return PathTerminator::kVM;
+  }
+  if (token == "PI") {
+    return PathTerminator::kPI;
+  }
+  if (token == "HM") {
+    return PathTerminator::kHM;
+  }
+  if (token == "HF") {
+    return PathTerminator::kHF;
+  }
   return PathTerminator::kUnknown;
 }
 

--- a/core/domain/procedure.h
+++ b/core/domain/procedure.h
@@ -72,6 +72,13 @@ struct AltitudeConstraint {
   int alt2_ft = 0;
 };
 
+// Parse the altitude restriction from the descriptor and the two altitude
+// values. `desc` is '+', '-', '@'/blank, or 'B' (the CIFP/DFD altitude
+// descriptor); alt1/alt2 are feet as stored. Shared by the X-Plane CIFP parser
+// and the DFD SQLite loaders so the column-extraction differs but the
+// descriptor logic does not.
+AltitudeConstraint ParseAltConstraint(std::string_view desc, int alt1, int alt2);
+
 // One leg of a procedure: the path terminator, its (possibly empty) fix, and
 // the course/distance/altitude data parsed from the CIFP row. Legs that do not
 // terminate at a fix leave `fix` empty and rely on course/distance.
@@ -112,6 +119,14 @@ struct Runway {
   std::string ident{};   // e.g. "RW31L"
   Coordinate threshold;  // threshold position
   int elevation_ft = 0;
+};
+
+// The procedures and runways parsed from one airport's terminal-procedure data
+// (X-Plane CIFP files or DFD SQLite procedure tables). Pure data, not specific
+// to any source format, so it lives in core rather than under a single loader.
+struct CifpData {
+  std::vector<Procedure> procedures;
+  std::vector<Runway> runways;
 };
 
 }  // namespace bf

--- a/core/env.h
+++ b/core/env.h
@@ -40,4 +40,3 @@ inline bool SetEnv(const char* name, const std::string& value) {
 }
 
 }  // namespace bf
-

--- a/core/env.h
+++ b/core/env.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdlib>
+#include <string>
 
 namespace bf {
 
@@ -18,4 +19,25 @@ inline const char* GetEnv(const char* name) {
 #endif
 }
 
+// Thin wrapper around setenv (POSIX) / _putenv_s (MSVC). Sets `name` to `value`
+// for the current process and any children it spawns afterwards. Used by tests
+// to switch the navigation-data source at runtime. Returns true on success.
+inline bool SetEnv(const char* name, const std::string& value) {
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+  const int rc =
+#ifdef _MSC_VER
+      _putenv_s(name, value.c_str());
+#else
+      setenv(name, value.c_str(), /*overwrite=*/1);
+#endif
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+  return rc == 0;
+}
+
 }  // namespace bf
+

--- a/core/graph/nav_graph.h
+++ b/core/graph/nav_graph.h
@@ -9,8 +9,9 @@ namespace bf {
 
 // Bit flags packed into GraphEdge::flags.
 enum EdgeFlag : uint8_t {
-  kEdgeHigh = 1u << 0,  // Jet (high) airway; clear = Victor (low). Remaining
-                        // bits are reserved for future constraints (RAD/CDR).
+  kEdgeHigh = 1u << 0,  // Jet (high) airway; clear = Victor (low).
+  kEdgeBoth = 1u << 1,  // usable at both high and low (DFD flightlevel 'B'); never
+                        // penalized by level preference. Remaining bits reserved.
 };
 
 // A directed edge in the navigation graph, stored in compressed-sparse-row
@@ -36,6 +37,9 @@ static_assert(sizeof(GraphEdge) == 16, "GraphEdge is expected to be 16 bytes");
 
 // Whether an edge belongs to a high (Jet) airway.
 inline bool EdgeIsHigh(const GraphEdge& e) { return (e.flags & kEdgeHigh) != 0; }
+
+// Whether an edge is usable at both high and low levels (never level-filtered).
+inline bool EdgeIsBoth(const GraphEdge& e) { return (e.flags & kEdgeBoth) != 0; }
 
 // An immutable directed graph over navigation waypoints, stored as CSR for
 // cache-friendly traversal. Vertices are integer indices; each vertex carries

--- a/docs/binary-cache.zh-CN.md
+++ b/docs/binary-cache.zh-CN.md
@@ -134,8 +134,8 @@ uint8  flags        // bit0=is_high，余位 RAD/CDR 预留
   仍毫秒级，不常驻全部程序；
 - **eager 模式**：`Open` 时 `FetchAll` 全量反序列化进内存并冻结（~102MB），之后无锁读，面向
   Web/批量并发。
-- **段可缺席**：`--without-cifp` 时 CIFP 段的段表项 offset/length 置 0，`Open` 见 0 即知无此段，
-  airport 报告无程序。
+- **CIFP 段强制写入**：无程序的缓存无法解析 SID/STAR，故 CIFP 段始终写入、段表项 offset/length
+  非零；airport 程序由该段提供，缺席即报告无程序。
 
 `--data` 指空目录仍能从缓存出全 SID/STAR、与文件路径逐字节一致。
 

--- a/docs/performance.zh-CN.md
+++ b/docs/performance.zh-CN.md
@@ -122,8 +122,7 @@ Lawler 之后再做一轮 profile（gprof，KJFK→KLAX k=10、400 轮、`-pg -O
 ## 6. 缓存文件大小
 
 一个统一 `nav_<cycle>.bfdb` 装三段（graph + CIFP + detail），共用一个全局字符串池。实测
-cycle 2601 整文件 **57.3 MB**；`--without-cifp`（仅 graph + detail + 池）**18.9 MB**，反推
-CIFP 段 **~38 MB**：
+cycle 2601 整文件 **57.3 MB**，其中 CIFP 段约 ~38 MB：
 
 | 段 | 约占 | 内容 |
 |---|---:|---|

--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -1,6 +1,9 @@
 # The I/O layer: data loaders, graph builder, and the NavDatabase facade.
 add_library(bf_io
+            loaders/sqlite_util.cc
             loaders/loader_registry.cc
+            loaders/dfd1/dfd1_loader.cc
+            loaders/dfd2/dfd2_loader.cc
             loaders/xplane12/xplane12_loader.cc
             loaders/xplane12/cifp/cifp_parser.cc
             loaders/xplane12/cifp/procedure_connector.cc
@@ -19,5 +22,8 @@ add_library(bf_io
 target_include_directories(bf_io PUBLIC ${PROJECT_SOURCE_DIR})
 
 target_link_libraries(bf_io PUBLIC bf::core)
+# The DFD SQLite loaders (added in their own source files) link sqlite3 here.
+# PRIVATE because no bf_io header exposes sqlite3.
+target_link_libraries(bf_io PRIVATE bf::sqlite3)
 
 add_library(bf::io ALIAS bf_io)

--- a/io/cache/bfdb_inventory.cc
+++ b/io/cache/bfdb_inventory.cc
@@ -68,18 +68,14 @@ std::optional<BfdbEntry> BfdbInventory::Latest() const {
   }
   // entries_ is sorted by cycle ascending, so the last element is the newest.
   assert(std::is_sorted(entries_.begin(), entries_.end(),
-                        [](const BfdbEntry& a, const BfdbEntry& b) {
-                          return a.cycle < b.cycle;
-                        }));
+                        [](const BfdbEntry& a, const BfdbEntry& b) { return a.cycle < b.cycle; }));
   return entries_.back();
 }
 
 std::optional<BfdbEntry> BfdbInventory::Find(uint32_t cycle) const {
   // entries_ is sorted by cycle ascending, so binary-search for the cycle.
   assert(std::is_sorted(entries_.begin(), entries_.end(),
-                        [](const BfdbEntry& a, const BfdbEntry& b) {
-                          return a.cycle < b.cycle;
-                        }));
+                        [](const BfdbEntry& a, const BfdbEntry& b) { return a.cycle < b.cycle; }));
   auto it = std::lower_bound(entries_.begin(), entries_.end(), cycle,
                              [](const BfdbEntry& e, uint32_t c) { return e.cycle < c; });
   if (it != entries_.end() && it->cycle == cycle) {

--- a/io/cache/nav_detail_codec.cc
+++ b/io/cache/nav_detail_codec.cc
@@ -197,19 +197,22 @@ NavDetailArchive NavDetailArchive::FromData(const NavData& data) {
 void NavDetailArchive::Finalize() {
   // Sort both arrays for binary-search lookup.
   std::sort(navaids_.begin(), navaids_.end(), [](const auto& a, const auto& b) {
-    if (a.first.ident != b.first.ident) return a.first.ident < b.first.ident;
+    if (a.first.ident != b.first.ident) {
+      return a.first.ident < b.first.ident;
+    }
     return a.first.region < b.first.region;
   });
   assert(std::is_sorted(navaids_.begin(), navaids_.end(), [](const auto& a, const auto& b) {
-    if (a.first.ident != b.first.ident) return a.first.ident < b.first.ident;
+    if (a.first.ident != b.first.ident) {
+      return a.first.ident < b.first.ident;
+    }
     return a.first.region < b.first.region;
   }));
   std::sort(holds_.begin(), holds_.end(),
             [](const HoldInfo& a, const HoldInfo& b) { return a.fix_ident < b.fix_ident; });
-  assert(std::is_sorted(holds_.begin(), holds_.end(),
-                        [](const HoldInfo& a, const HoldInfo& b) {
-                          return a.fix_ident < b.fix_ident;
-                        }));
+  assert(std::is_sorted(holds_.begin(), holds_.end(), [](const HoldInfo& a, const HoldInfo& b) {
+    return a.fix_ident < b.fix_ident;
+  }));
   loaded_ = true;
 }
 
@@ -221,7 +224,9 @@ std::vector<NavaidDetailInfo> NavDetailArchive::FindNavaids(const std::string& i
     return out;
   }
   assert(std::is_sorted(navaids_.begin(), navaids_.end(), [](const auto& a, const auto& b) {
-    if (a.first.ident != b.first.ident) return a.first.ident < b.first.ident;
+    if (a.first.ident != b.first.ident) {
+      return a.first.ident < b.first.ident;
+    }
     return a.first.region < b.first.region;
   }));
   // lower_bound on ident string; collect all matching ident (any region).
@@ -239,10 +244,9 @@ std::vector<HoldInfo> NavDetailArchive::FindHolds(const std::string& ident) cons
   if (!loaded_) {
     return out;
   }
-  assert(std::is_sorted(holds_.begin(), holds_.end(),
-                        [](const HoldInfo& a, const HoldInfo& b) {
-                          return a.fix_ident < b.fix_ident;
-                        }));
+  assert(std::is_sorted(holds_.begin(), holds_.end(), [](const HoldInfo& a, const HoldInfo& b) {
+    return a.fix_ident < b.fix_ident;
+  }));
   // holds_ is sorted by fix_ident; use lower/upper_bound to find the range.
   auto cmp = [](const HoldInfo& h, const std::string& key) { return h.fix_ident < key; };
   auto lo = std::lower_bound(holds_.begin(), holds_.end(), ident, cmp);

--- a/io/graph_builder.cc
+++ b/io/graph_builder.cc
@@ -99,7 +99,9 @@ GraphBuilder::GraphBuilder(const NavData& data, int airport_dct_count) {
   std::vector<std::vector<GraphEdge>> adj(total);
   auto add_edge = [&](int from, int to, uint16_t airway_id, const AirwaySegment& s) {
     const double dist = graph_.coords_[from].DistanceTo(graph_.coords_[to]);
-    const uint8_t flags = s.level == AirwayLevel::kHigh ? kEdgeHigh : 0;
+    uint8_t flags = 0;
+    if (s.level == AirwayLevel::kHigh) flags |= kEdgeHigh;
+    if (s.level == AirwayLevel::kBoth) flags |= kEdgeBoth;  // DFD flightlevel 'B'
     adj[from].push_back(GraphEdge{to, static_cast<float>(dist), airway_id,
                                   static_cast<int16_t>(s.base_fl), static_cast<int16_t>(s.top_fl),
                                   flags});

--- a/io/graph_builder.cc
+++ b/io/graph_builder.cc
@@ -100,8 +100,12 @@ GraphBuilder::GraphBuilder(const NavData& data, int airport_dct_count) {
   auto add_edge = [&](int from, int to, uint16_t airway_id, const AirwaySegment& s) {
     const double dist = graph_.coords_[from].DistanceTo(graph_.coords_[to]);
     uint8_t flags = 0;
-    if (s.level == AirwayLevel::kHigh) flags |= kEdgeHigh;
-    if (s.level == AirwayLevel::kBoth) flags |= kEdgeBoth;  // DFD flightlevel 'B'
+    if (s.level == AirwayLevel::kHigh) {
+      flags |= kEdgeHigh;
+    }
+    if (s.level == AirwayLevel::kBoth) {
+      flags |= kEdgeBoth;  // DFD flightlevel 'B'
+    }
     adj[from].push_back(GraphEdge{to, static_cast<float>(dist), airway_id,
                                   static_cast<int16_t>(s.base_fl), static_cast<int16_t>(s.top_fl),
                                   flags});

--- a/io/loaders/dfd1/dfd1_loader.cc
+++ b/io/loaders/dfd1/dfd1_loader.cc
@@ -1,5 +1,7 @@
 #include "io/loaders/dfd1/dfd1_loader.h"
 
+#include <sqlite3.h>
+
 #include <algorithm>
 #include <charconv>
 #include <cmath>
@@ -10,10 +12,8 @@
 #include <unordered_set>
 #include <utility>
 
-#include <sqlite3.h>
-
-#include "core/domain/airway.h"
 #include "core/domain/airport.h"
+#include "core/domain/airway.h"
 #include "core/domain/hold_fix.h"
 #include "core/domain/ident.h"
 #include "core/domain/mora_grid.h"
@@ -74,8 +74,8 @@ Result<void> CheckV1Header(sqlite3* conn) {
   }
   if (version.empty() || version.rfind("1.", 0) != 0) {
     return Result<void>::Err(Error(ErrorCode::kInvalidArgument,
-        "not a DFD v1.0 database (tbl_header missing or wrong version); "
-        "for DFD v2 use --loader dfd2"));
+                                   "not a DFD v1.0 database (tbl_header missing or wrong version); "
+                                   "for DFD v2 use --loader dfd2"));
   }
   return Result<void>::Ok();
 }
@@ -103,9 +103,10 @@ WaypointKind NavaidKindFromClass(const std::string& cls) {
 
 void LoadEnrouteWaypoints(sqlite3* conn, NavData& data, std::unordered_set<Ident>& seen) {
   // 0=icao_code 1=waypoint_identifier 2=lat 3=lon
-  Result<SqliteStmt> s = Prepare(conn,
-      "SELECT icao_code, waypoint_identifier, waypoint_latitude, waypoint_longitude "
-      "FROM tbl_enroute_waypoints");
+  Result<SqliteStmt> s =
+      Prepare(conn,
+              "SELECT icao_code, waypoint_identifier, waypoint_latitude, waypoint_longitude "
+              "FROM tbl_enroute_waypoints");
   if (!s) {
     return;
   }
@@ -113,17 +114,18 @@ void LoadEnrouteWaypoints(sqlite3* conn, NavData& data, std::unordered_set<Ident
   while (Step(stmt).value_or(false)) {
     const Ident key(ColumnText(stmt, 1), ColumnText(stmt, 0));
     if (seen.insert(key).second) {
-      data.waypoints.push_back(
-          Waypoint{key, Coordinate{ColumnDouble(stmt, 2), ColumnDouble(stmt, 3)}, WaypointKind::kFix});
+      data.waypoints.push_back(Waypoint{
+          key, Coordinate{ColumnDouble(stmt, 2), ColumnDouble(stmt, 3)}, WaypointKind::kFix});
     }
   }
 }
 
 void LoadTerminalWaypoints(sqlite3* conn, NavData& data, std::unordered_set<Ident>& seen) {
   // 0=region_code 1=waypoint_identifier 2=lat 3=lon
-  Result<SqliteStmt> s = Prepare(conn,
-      "SELECT region_code, waypoint_identifier, waypoint_latitude, waypoint_longitude "
-      "FROM tbl_terminal_waypoints");
+  Result<SqliteStmt> s =
+      Prepare(conn,
+              "SELECT region_code, waypoint_identifier, waypoint_latitude, waypoint_longitude "
+              "FROM tbl_terminal_waypoints");
   if (!s) {
     return;
   }
@@ -131,8 +133,8 @@ void LoadTerminalWaypoints(sqlite3* conn, NavData& data, std::unordered_set<Iden
   while (Step(stmt).value_or(false)) {
     const Ident key(ColumnText(stmt, 1), ColumnText(stmt, 0));
     if (seen.insert(key).second) {
-      data.waypoints.push_back(
-          Waypoint{key, Coordinate{ColumnDouble(stmt, 2), ColumnDouble(stmt, 3)}, WaypointKind::kFix});
+      data.waypoints.push_back(Waypoint{
+          key, Coordinate{ColumnDouble(stmt, 2), ColumnDouble(stmt, 3)}, WaypointKind::kFix});
     }
   }
 }
@@ -140,7 +142,8 @@ void LoadTerminalWaypoints(sqlite3* conn, NavData& data, std::unordered_set<Iden
 void LoadVhfNavaids(sqlite3* conn, NavData& data, std::unordered_set<Ident>& seen) {
   // 0=icao_code 1=vor_identifier 2=vor_frequency 3=navaid_class 4=range
   // 5=station_declination 6=dme_elevation 7=vor_lat 8=vor_lon
-  Result<SqliteStmt> s = Prepare(conn,
+  Result<SqliteStmt> s = Prepare(
+      conn,
       "SELECT icao_code, vor_identifier, vor_frequency, navaid_class, range, "
       "station_declination, dme_elevation, vor_latitude, vor_longitude FROM tbl_vhfnavaids");
   if (!s) {
@@ -160,15 +163,17 @@ void LoadVhfNavaids(sqlite3* conn, NavData& data, std::unordered_set<Ident>& see
         Waypoint{key, Coordinate{ColumnDouble(stmt, 7), ColumnDouble(stmt, 8)}, kind});
     // DFD vor_frequency is MHz (e.g. 115.9); NavaidDetail.freq_raw is MHz*100.
     const int freq_raw = static_cast<int>(std::lround(ColumnDouble(stmt, 2) * 100.0));
-    data.navaid_details.push_back(NavaidDetail{
-        key, kind, ColumnInt(stmt, 6), freq_raw, ColumnDouble(stmt, 4), ColumnDouble(stmt, 5)});
+    data.navaid_details.push_back(NavaidDetail{key, kind, ColumnInt(stmt, 6), freq_raw,
+                                               ColumnDouble(stmt, 4), ColumnDouble(stmt, 5)});
   }
 }
 
-void LoadNdbNavaids(sqlite3* conn, NavData& data, const char* table, std::unordered_set<Ident>& seen) {
+void LoadNdbNavaids(sqlite3* conn, NavData& data, const char* table,
+                    std::unordered_set<Ident>& seen) {
   // 0=icao_code 1=ndb_identifier 2=ndb_frequency 3=range 4=lat 5=lon
-  const std::string sql = std::string("SELECT icao_code, ndb_identifier, ndb_frequency, range, "
-                                      "ndb_latitude, ndb_longitude FROM ") +
+  const std::string sql = std::string(
+                              "SELECT icao_code, ndb_identifier, ndb_frequency, range, "
+                              "ndb_latitude, ndb_longitude FROM ") +
                           table;
   Result<SqliteStmt> s = Prepare(conn, sql);
   if (!s) {
@@ -180,11 +185,11 @@ void LoadNdbNavaids(sqlite3* conn, NavData& data, const char* table, std::unorde
     if (!seen.insert(key).second) {
       continue;
     }
-    data.waypoints.push_back(
-        Waypoint{key, Coordinate{ColumnDouble(stmt, 4), ColumnDouble(stmt, 5)}, WaypointKind::kNdb});
+    data.waypoints.push_back(Waypoint{key, Coordinate{ColumnDouble(stmt, 4), ColumnDouble(stmt, 5)},
+                                      WaypointKind::kNdb});
     // NDB frequency is kHz; freq_raw stores kHz as-is.
-    data.navaid_details.push_back(NavaidDetail{
-        key, WaypointKind::kNdb, 0, ColumnInt(stmt, 2), ColumnDouble(stmt, 3), 0.0});
+    data.navaid_details.push_back(
+        NavaidDetail{key, WaypointKind::kNdb, 0, ColumnInt(stmt, 2), ColumnDouble(stmt, 3), 0.0});
   }
 }
 
@@ -193,11 +198,12 @@ void LoadAirways(sqlite3* conn, NavData& data) {
   // seqno) form segments. 0=route_identifier 1=seqno 2=waypoint_identifier
   // 3=icao_code 4=direction_restriction 5=flightlevel 6=minimum_altitude1
   // 7=maximum_altitude 8=outbound_course 9=inbound_course
-  Result<SqliteStmt> s = Prepare(conn,
-      "SELECT route_identifier, seqno, waypoint_identifier, icao_code, "
-      "direction_restriction, flightlevel, minimum_altitude1, maximum_altitude, "
-      "outbound_course, inbound_course FROM tbl_enroute_airways "
-      "ORDER BY route_identifier, seqno");
+  Result<SqliteStmt> s =
+      Prepare(conn,
+              "SELECT route_identifier, seqno, waypoint_identifier, icao_code, "
+              "direction_restriction, flightlevel, minimum_altitude1, maximum_altitude, "
+              "outbound_course, inbound_course FROM tbl_enroute_airways "
+              "ORDER BY route_identifier, seqno");
   if (!s) {
     return;
   }
@@ -212,7 +218,7 @@ void LoadAirways(sqlite3* conn, NavData& data) {
     if (have_prev && route == prev_route) {
       seg.name = prev_route;
       seg.direction = ParseDirection(ColumnText(stmt, 4));  // from-row direction
-      seg.level = ParseAirwayLevel(ColumnText(stmt, 5));     // 'H'/'L'/'B'
+      seg.level = ParseAirwayLevel(ColumnText(stmt, 5));    // 'H'/'L'/'B'
       // DFD altitudes are FEET; base_fl/top_fl are flight levels (feet/100).
       // DFD encodes "no ceiling" as maximum_altitude=99999 -> top_fl=999. That is
       // a very high finite band, NOT the base_fl==0 && top_fl==0 "no recorded
@@ -233,16 +239,16 @@ void LoadAirways(sqlite3* conn, NavData& data) {
 void LoadAirports(sqlite3* conn, NavData& data) {
   // 0=icao_code 1=airport_identifier 2=lat 3=lon 4=elevation
   Result<SqliteStmt> s = Prepare(conn,
-      "SELECT icao_code, airport_identifier, airport_ref_latitude, "
-      "airport_ref_longitude, elevation FROM tbl_airports");
+                                 "SELECT icao_code, airport_identifier, airport_ref_latitude, "
+                                 "airport_ref_longitude, elevation FROM tbl_airports");
   if (!s) {
     return;
   }
   sqlite3_stmt* stmt = s.value().get();
   while (Step(stmt).value_or(false)) {
     data.airports.push_back(Airport{ColumnText(stmt, 1), ColumnText(stmt, 0),
-                                   Coordinate{ColumnDouble(stmt, 2), ColumnDouble(stmt, 3)},
-                                   ColumnInt(stmt, 4)});
+                                    Coordinate{ColumnDouble(stmt, 2), ColumnDouble(stmt, 3)},
+                                    ColumnInt(stmt, 4)});
   }
 }
 
@@ -250,10 +256,11 @@ void LoadHoldings(sqlite3* conn, NavData& data) {
   // 0=region_code 1=icao_code 2=waypoint_identifier 3=inbound_holding_course
   // 4=turn_direction 5=leg_length 6=leg_time 7=minimum_altitude 8=maximum_altitude
   // 9=holding_speed
-  Result<SqliteStmt> s = Prepare(conn,
-      "SELECT region_code, icao_code, waypoint_identifier, inbound_holding_course, "
-      "turn_direction, leg_length, leg_time, minimum_altitude, maximum_altitude, "
-      "holding_speed FROM tbl_holdings");
+  Result<SqliteStmt> s =
+      Prepare(conn,
+              "SELECT region_code, icao_code, waypoint_identifier, inbound_holding_course, "
+              "turn_direction, leg_length, leg_time, minimum_altitude, maximum_altitude, "
+              "holding_speed FROM tbl_holdings");
   if (!s) {
     return;
   }
@@ -279,12 +286,13 @@ void LoadHoldings(sqlite3* conn, NavData& data) {
 void LoadMsa(sqlite3* conn, NavData& data) {
   // 0=airport_identifier 1=msa_center 2=msa_center_latitude 3=msa_center_longitude
   // 4=radius_limit 5..6=sector1(bearing,alt) 7..8=sector2 ...
-  Result<SqliteStmt> s = Prepare(conn,
-      "SELECT airport_identifier, msa_center, msa_center_latitude, "
-      "msa_center_longitude, radius_limit, "
-      "sector_bearing_1, sector_altitude_1, sector_bearing_2, sector_altitude_2, "
-      "sector_bearing_3, sector_altitude_3, sector_bearing_4, sector_altitude_4, "
-      "sector_bearing_5, sector_altitude_5 FROM tbl_airport_msa");
+  Result<SqliteStmt> s =
+      Prepare(conn,
+              "SELECT airport_identifier, msa_center, msa_center_latitude, "
+              "msa_center_longitude, radius_limit, "
+              "sector_bearing_1, sector_altitude_1, sector_bearing_2, sector_altitude_2, "
+              "sector_bearing_3, sector_altitude_3, sector_bearing_4, sector_altitude_4, "
+              "sector_bearing_5, sector_altitude_5 FROM tbl_airport_msa");
   if (!s) {
     return;
   }
@@ -314,12 +322,13 @@ void LoadMsa(sqlite3* conn, NavData& data) {
 void LoadGridMora(sqlite3* conn, NavData& data) {
   // v1: starting_latitude/longitude are INTEGER. mora01..mora30 are TEXT(3) ("010"
   // or "UNK"). Each row covers 30 one-degree cells of longitude from lon0.
-  Result<SqliteStmt> s = Prepare(conn,
-      "SELECT starting_latitude, starting_longitude, "
-      "mora01, mora02, mora03, mora04, mora05, mora06, mora07, mora08, mora09, mora10, "
-      "mora11, mora12, mora13, mora14, mora15, mora16, mora17, mora18, mora19, mora20, "
-      "mora21, mora22, mora23, mora24, mora25, mora26, mora27, mora28, mora29, mora30 "
-      "FROM tbl_grid_mora");
+  Result<SqliteStmt> s =
+      Prepare(conn,
+              "SELECT starting_latitude, starting_longitude, "
+              "mora01, mora02, mora03, mora04, mora05, mora06, mora07, mora08, mora09, mora10, "
+              "mora11, mora12, mora13, mora14, mora15, mora16, mora17, mora18, mora19, mora20, "
+              "mora21, mora22, mora23, mora24, mora25, mora26, mora27, mora28, mora29, mora30 "
+              "FROM tbl_grid_mora");
   if (!s) {
     return;
   }
@@ -389,18 +398,18 @@ namespace {
 // the SELECT defined in LoadProcTable. v2 reorders/renames some columns, so
 // Dfd2Loader defines its own layout; here is v1's.
 struct ProcCols {
-  int airport = 0;    // airport_identifier
+  int airport = 0;     // airport_identifier
   int proc = 1;        // procedure_identifier
   int route_type = 2;  // route_type (numeric for SID/STAR, alpha for IAP)
   int transition = 3;  // transition_identifier
   int seqno = 4;       // seqno
   int wp_ident = 5;    // waypoint_identifier
-  int wp_icao = 6;    // waypoint_icao_code
-  int path_term = 7;  // path_termination
+  int wp_icao = 6;     // waypoint_icao_code
+  int path_term = 7;   // path_termination
   int course = 8;      // magnetic_course
   int dist_value = 9;  // route_distance_holding_distance_time (REAL)
   int dist_flag = 10;  // distance_time (TEXT 'D'/'T'/blank)
-  int alt_desc = 11;  // altitude_description
+  int alt_desc = 11;   // altitude_description
   int alt1 = 12;       // altitude1
   int alt2 = 13;       // altitude2
 };
@@ -413,13 +422,15 @@ struct ProcCols {
 // CifpData. This avoids per-airport `Prepare` (~7k airports x 3 tables).
 void LoadProcTable(sqlite3* conn, const char* table, ProcedureType type,
                    std::vector<AirportProcedureData>& out) {
-  const std::string sql = std::string(
-      "SELECT airport_identifier, procedure_identifier, route_type, "
-      "transition_identifier, seqno, waypoint_identifier, waypoint_icao_code, "
-      "path_termination, magnetic_course, route_distance_holding_distance_time, "
-      "distance_time, altitude_description, altitude1, altitude2 FROM ") +
-      table + " ORDER BY airport_identifier, procedure_identifier, "
-              "transition_identifier, seqno";
+  const std::string sql =
+      std::string(
+          "SELECT airport_identifier, procedure_identifier, route_type, "
+          "transition_identifier, seqno, waypoint_identifier, waypoint_icao_code, "
+          "path_termination, magnetic_course, route_distance_holding_distance_time, "
+          "distance_time, altitude_description, altitude1, altitude2 FROM ") +
+      table +
+      " ORDER BY airport_identifier, procedure_identifier, "
+      "transition_identifier, seqno";
   Result<SqliteStmt> s = Prepare(conn, sql);
   if (!s) {
     return;
@@ -457,8 +468,7 @@ void LoadProcTable(sqlite3* conn, const char* table, ProcedureType type,
     if (airport != cur_airport) {
       flush_airport();
       cur_airport = airport;
-    } else if (have_current &&
-               (name != cur_name || trans != cur_trans || route != cur_route)) {
+    } else if (have_current && (name != cur_name || trans != cur_trans || route != cur_route)) {
       flush_proc();
     }
     if (!have_current) {
@@ -501,9 +511,9 @@ void LoadProcTable(sqlite3* conn, const char* table, ProcedureType type,
 std::unordered_map<std::string, std::vector<Runway>> LoadAllRunways(sqlite3* conn) {
   std::unordered_map<std::string, std::vector<Runway>> by_airport;
   Result<SqliteStmt> s = Prepare(conn,
-      "SELECT airport_identifier, runway_identifier, runway_latitude, "
-      "runway_longitude, landing_threshold_elevation FROM tbl_runways "
-      "ORDER BY airport_identifier");
+                                 "SELECT airport_identifier, runway_identifier, runway_latitude, "
+                                 "runway_longitude, landing_threshold_elevation FROM tbl_runways "
+                                 "ORDER BY airport_identifier");
   if (!s) {
     return by_airport;
   }
@@ -522,7 +532,7 @@ std::unordered_map<std::string, std::vector<Runway>> LoadAllRunways(sqlite3* con
 // only to airports that already have procedures (an airport with procedures but
 // no runways, or vice versa, is handled by the procedure scan).
 void MergeRunways(std::vector<AirportProcedureData>& out,
-                 std::unordered_map<std::string, std::vector<Runway>>& runways) {
+                  std::unordered_map<std::string, std::vector<Runway>>& runways) {
   for (AirportProcedureData& ap : out) {
     auto it = runways.find(ap.first);
     if (it != runways.end()) {
@@ -547,15 +557,17 @@ void MergeRunways(std::vector<AirportProcedureData>& out,
 std::optional<CifpData> LoadAirportProcedures(sqlite3* conn, const std::string& airport) {
   CifpData cifp;
   for (const auto& [table, type] : {std::pair{"tbl_sids", ProcedureType::kSid},
-                                     {"tbl_stars", ProcedureType::kStar},
-                                     {"tbl_iaps", ProcedureType::kApproach}}) {
-    const std::string sql = std::string(
-        "SELECT airport_identifier, procedure_identifier, route_type, "
-        "transition_identifier, seqno, waypoint_identifier, waypoint_icao_code, "
-        "path_termination, magnetic_course, route_distance_holding_distance_time, "
-        "distance_time, altitude_description, altitude1, altitude2 FROM ") +
-        table + " WHERE airport_identifier = ? ORDER BY procedure_identifier, "
-                "transition_identifier, seqno";
+                                    {"tbl_stars", ProcedureType::kStar},
+                                    {"tbl_iaps", ProcedureType::kApproach}}) {
+    const std::string sql =
+        std::string(
+            "SELECT airport_identifier, procedure_identifier, route_type, "
+            "transition_identifier, seqno, waypoint_identifier, waypoint_icao_code, "
+            "path_termination, magnetic_course, route_distance_holding_distance_time, "
+            "distance_time, altitude_description, altitude1, altitude2 FROM ") +
+        table +
+        " WHERE airport_identifier = ? ORDER BY procedure_identifier, "
+        "transition_identifier, seqno";
     Result<SqliteStmt> s = Prepare(conn, sql);
     if (!s) {
       continue;
@@ -610,9 +622,10 @@ std::optional<CifpData> LoadAirportProcedures(sqlite3* conn, const std::string& 
     }
   }
   // Runways for this airport.
-  Result<SqliteStmt> rs = Prepare(conn,
-      "SELECT runway_identifier, runway_latitude, runway_longitude, "
-      "landing_threshold_elevation FROM tbl_runways WHERE airport_identifier = ?");
+  Result<SqliteStmt> rs =
+      Prepare(conn,
+              "SELECT runway_identifier, runway_latitude, runway_longitude, "
+              "landing_threshold_elevation FROM tbl_runways WHERE airport_identifier = ?");
   if (rs) {
     sqlite3_stmt* stmt = rs.value().get();
     sqlite3_bind_text(stmt, 1, airport.c_str(), -1, SQLITE_TRANSIENT);
@@ -660,7 +673,7 @@ Result<std::vector<AirportProcedureData>> Dfd1Loader::LoadProcedures(
       auto& dst = merged.back().second.procedures;
       auto& src = ap.second.procedures;
       dst.insert(dst.end(), std::make_move_iterator(src.begin()),
-                  std::make_move_iterator(src.end()));
+                 std::make_move_iterator(src.end()));
     } else {
       merged.push_back(std::move(ap));
     }
@@ -671,7 +684,7 @@ Result<std::vector<AirportProcedureData>> Dfd1Loader::LoadProcedures(
 }
 
 std::optional<CifpData> Dfd1Loader::LoadProcedure(const std::string& source_dir,
-                                                   const std::string& icao) const {
+                                                  const std::string& icao) const {
   Result<std::string> db_path = FindV1Db(source_dir);
   if (!db_path) {
     return std::nullopt;
@@ -684,4 +697,3 @@ std::optional<CifpData> Dfd1Loader::LoadProcedure(const std::string& source_dir,
 }
 
 }  // namespace bf
-

--- a/io/loaders/dfd1/dfd1_loader.cc
+++ b/io/loaders/dfd1/dfd1_loader.cc
@@ -1,0 +1,690 @@
+#include "io/loaders/dfd1/dfd1_loader.h"
+
+#include <algorithm>
+#include <charconv>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+#include <sqlite3.h>
+
+#include "core/domain/airway.h"
+#include "core/domain/airport.h"
+#include "core/domain/hold_fix.h"
+#include "core/domain/ident.h"
+#include "core/domain/mora_grid.h"
+#include "core/domain/msa.h"
+#include "core/domain/navaid_detail.h"
+#include "core/domain/procedure.h"
+#include "core/domain/waypoint.h"
+#include "core/result.h"
+#include "io/loaders/sqlite_util.h"
+#include "io/nav_data.h"
+
+namespace bf {
+namespace {
+
+// DFD v1.0 source loader. All table/row -> domain mapping is private to this TU.
+// Column access is positional against an explicit SELECT, so the table's native
+// column order never matters. Units that differ from X-Plane CIFP (the reference
+// loader) are called out inline.
+
+constexpr std::string_view kLoaderName = "dfd1";
+
+// Search source_dir for the v1 database (byte-identical copies under several
+// names), in priority order, falling back to the first *.s3db found.
+Result<std::string> FindV1Db(const std::string& source_dir) {
+  namespace fs = std::filesystem;
+  std::error_code ec;
+  if (!fs::is_directory(source_dir, ec)) {
+    return Result<std::string>::Err(
+        Error(ErrorCode::kDataMissing, "source directory not found: " + source_dir));
+  }
+  const char* kPreferred[] = {"navdb.s3db", "navdata.s3db", "e_dfd_PMDG.s3db"};
+  for (const char* name : kPreferred) {
+    fs::path p = fs::path(source_dir) / name;
+    if (fs::exists(p, ec)) {
+      return Result<std::string>::Ok(p.string());
+    }
+  }
+  for (const fs::directory_entry& de : fs::directory_iterator(source_dir, ec)) {
+    if (de.is_regular_file() && de.path().extension() == ".s3db") {
+      return Result<std::string>::Ok(de.path().string());
+    }
+  }
+  return Result<std::string>::Err(
+      Error(ErrorCode::kDataMissing, "no DFD v1 .s3db under " + source_dir));
+}
+
+// Verify the DB is DFD v1.0 (tbl_header.version starts with "1."). A missing
+// tbl_header (Prepare fails or no row) or a different version means the user
+// likely pointed dfd1 at a v2 DB (or vice versa); give an actionable message.
+Result<void> CheckV1Header(sqlite3* conn) {
+  Result<SqliteStmt> stmt = Prepare(conn, "SELECT version FROM tbl_header LIMIT 1");
+  std::string version;
+  if (stmt) {
+    Result<bool> row = Step(stmt.value().get());
+    if (row && row.value()) {
+      version = ColumnText(stmt.value().get(), 0);
+    }
+  }
+  if (version.empty() || version.rfind("1.", 0) != 0) {
+    return Result<void>::Err(Error(ErrorCode::kInvalidArgument,
+        "not a DFD v1.0 database (tbl_header missing or wrong version); "
+        "for DFD v2 use --loader dfd2"));
+  }
+  return Result<void>::Ok();
+}
+
+// Map a DFD navaid_class first character to a routable WaypointKind. See the
+// plan: V=VOR/VOR-DME/VORTAC, D/T/M=DME/TACAN (kDme), I/N/P=ILS/MLS components
+// (kOther, skipped), leading space = ILS/LOC component (kOther, skipped).
+WaypointKind NavaidKindFromClass(const std::string& cls) {
+  if (cls.empty()) {
+    return WaypointKind::kOther;
+  }
+  switch (cls[0]) {
+    case 'V':
+      return WaypointKind::kVor;
+    case 'D':
+    case 'T':
+    case 'M':
+      return WaypointKind::kDme;
+    default:
+      return WaypointKind::kOther;  // I/N/P or space-padded ILS component
+  }
+}
+
+// --- Per-table loaders. Each runs one query and appends to `data`. ---
+
+void LoadEnrouteWaypoints(sqlite3* conn, NavData& data, std::unordered_set<Ident>& seen) {
+  // 0=icao_code 1=waypoint_identifier 2=lat 3=lon
+  Result<SqliteStmt> s = Prepare(conn,
+      "SELECT icao_code, waypoint_identifier, waypoint_latitude, waypoint_longitude "
+      "FROM tbl_enroute_waypoints");
+  if (!s) {
+    return;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  while (Step(stmt).value_or(false)) {
+    const Ident key(ColumnText(stmt, 1), ColumnText(stmt, 0));
+    if (seen.insert(key).second) {
+      data.waypoints.push_back(
+          Waypoint{key, Coordinate{ColumnDouble(stmt, 2), ColumnDouble(stmt, 3)}, WaypointKind::kFix});
+    }
+  }
+}
+
+void LoadTerminalWaypoints(sqlite3* conn, NavData& data, std::unordered_set<Ident>& seen) {
+  // 0=region_code 1=waypoint_identifier 2=lat 3=lon
+  Result<SqliteStmt> s = Prepare(conn,
+      "SELECT region_code, waypoint_identifier, waypoint_latitude, waypoint_longitude "
+      "FROM tbl_terminal_waypoints");
+  if (!s) {
+    return;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  while (Step(stmt).value_or(false)) {
+    const Ident key(ColumnText(stmt, 1), ColumnText(stmt, 0));
+    if (seen.insert(key).second) {
+      data.waypoints.push_back(
+          Waypoint{key, Coordinate{ColumnDouble(stmt, 2), ColumnDouble(stmt, 3)}, WaypointKind::kFix});
+    }
+  }
+}
+
+void LoadVhfNavaids(sqlite3* conn, NavData& data, std::unordered_set<Ident>& seen) {
+  // 0=icao_code 1=vor_identifier 2=vor_frequency 3=navaid_class 4=range
+  // 5=station_declination 6=dme_elevation 7=vor_lat 8=vor_lon
+  Result<SqliteStmt> s = Prepare(conn,
+      "SELECT icao_code, vor_identifier, vor_frequency, navaid_class, range, "
+      "station_declination, dme_elevation, vor_latitude, vor_longitude FROM tbl_vhfnavaids");
+  if (!s) {
+    return;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  while (Step(stmt).value_or(false)) {
+    const WaypointKind kind = NavaidKindFromClass(ColumnText(stmt, 3));
+    if (kind == WaypointKind::kOther) {
+      continue;  // ILS/LOC component: not enroute-routable
+    }
+    const Ident key(ColumnText(stmt, 1), ColumnText(stmt, 0));
+    if (!seen.insert(key).second) {
+      continue;
+    }
+    data.waypoints.push_back(
+        Waypoint{key, Coordinate{ColumnDouble(stmt, 7), ColumnDouble(stmt, 8)}, kind});
+    // DFD vor_frequency is MHz (e.g. 115.9); NavaidDetail.freq_raw is MHz*100.
+    const int freq_raw = static_cast<int>(std::lround(ColumnDouble(stmt, 2) * 100.0));
+    data.navaid_details.push_back(NavaidDetail{
+        key, kind, ColumnInt(stmt, 6), freq_raw, ColumnDouble(stmt, 4), ColumnDouble(stmt, 5)});
+  }
+}
+
+void LoadNdbNavaids(sqlite3* conn, NavData& data, const char* table, std::unordered_set<Ident>& seen) {
+  // 0=icao_code 1=ndb_identifier 2=ndb_frequency 3=range 4=lat 5=lon
+  const std::string sql = std::string("SELECT icao_code, ndb_identifier, ndb_frequency, range, "
+                                      "ndb_latitude, ndb_longitude FROM ") +
+                          table;
+  Result<SqliteStmt> s = Prepare(conn, sql);
+  if (!s) {
+    return;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  while (Step(stmt).value_or(false)) {
+    const Ident key(ColumnText(stmt, 1), ColumnText(stmt, 0));
+    if (!seen.insert(key).second) {
+      continue;
+    }
+    data.waypoints.push_back(
+        Waypoint{key, Coordinate{ColumnDouble(stmt, 4), ColumnDouble(stmt, 5)}, WaypointKind::kNdb});
+    // NDB frequency is kHz; freq_raw stores kHz as-is.
+    data.navaid_details.push_back(NavaidDetail{
+        key, WaypointKind::kNdb, 0, ColumnInt(stmt, 2), ColumnDouble(stmt, 3), 0.0});
+  }
+}
+
+void LoadAirways(sqlite3* conn, NavData& data) {
+  // One row per waypoint on an airway; consecutive same-route_identifier rows (by
+  // seqno) form segments. 0=route_identifier 1=seqno 2=waypoint_identifier
+  // 3=icao_code 4=direction_restriction 5=flightlevel 6=minimum_altitude1
+  // 7=maximum_altitude 8=outbound_course 9=inbound_course
+  Result<SqliteStmt> s = Prepare(conn,
+      "SELECT route_identifier, seqno, waypoint_identifier, icao_code, "
+      "direction_restriction, flightlevel, minimum_altitude1, maximum_altitude, "
+      "outbound_course, inbound_course FROM tbl_enroute_airways "
+      "ORDER BY route_identifier, seqno");
+  if (!s) {
+    return;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  bool have_prev = false;
+  std::string prev_route, prev_ident, prev_icao;
+  AirwaySegment seg;
+  while (Step(stmt).value_or(false)) {
+    const std::string route = ColumnText(stmt, 0);
+    const std::string ident = ColumnText(stmt, 2);
+    const std::string icao = ColumnText(stmt, 3);
+    if (have_prev && route == prev_route) {
+      seg.name = prev_route;
+      seg.direction = ParseDirection(ColumnText(stmt, 4));  // from-row direction
+      seg.level = ParseAirwayLevel(ColumnText(stmt, 5));     // 'H'/'L'/'B'
+      // DFD altitudes are FEET; base_fl/top_fl are flight levels (feet/100).
+      seg.base_fl = ColumnInt(stmt, 6) / 100;
+      seg.top_fl = ColumnInt(stmt, 7) / 100;  // 99999 -> 999 (effectively unlimited)
+      data.airways.push_back(
+          AirwayConnection{Ident(prev_ident, prev_icao), Ident(ident, icao), seg});
+    }
+    prev_route = route;
+    prev_ident = ident;
+    prev_icao = icao;
+    have_prev = true;
+  }
+}
+
+void LoadAirports(sqlite3* conn, NavData& data) {
+  // 0=icao_code 1=airport_identifier 2=lat 3=lon 4=elevation
+  Result<SqliteStmt> s = Prepare(conn,
+      "SELECT icao_code, airport_identifier, airport_ref_latitude, "
+      "airport_ref_longitude, elevation FROM tbl_airports");
+  if (!s) {
+    return;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  while (Step(stmt).value_or(false)) {
+    data.airports.push_back(Airport{ColumnText(stmt, 1), ColumnText(stmt, 0),
+                                   Coordinate{ColumnDouble(stmt, 2), ColumnDouble(stmt, 3)},
+                                   ColumnInt(stmt, 4)});
+  }
+}
+
+void LoadHoldings(sqlite3* conn, NavData& data) {
+  // 0=region_code 1=icao_code 2=waypoint_identifier 3=inbound_holding_course
+  // 4=turn_direction 5=leg_length 6=leg_time 7=minimum_altitude 8=maximum_altitude
+  // 9=holding_speed
+  Result<SqliteStmt> s = Prepare(conn,
+      "SELECT region_code, icao_code, waypoint_identifier, inbound_holding_course, "
+      "turn_direction, leg_length, leg_time, minimum_altitude, maximum_altitude, "
+      "holding_speed FROM tbl_holdings");
+  if (!s) {
+    return;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  while (Step(stmt).value_or(false)) {
+    HoldFix h;
+    h.fix = Ident(ColumnText(stmt, 2), ColumnText(stmt, 1));  // region = icao_code
+    h.airport_icao = ColumnText(stmt, 0);                     // region_code = airport/ENRT
+    h.inbound_course = ColumnDouble(stmt, 3);
+    const std::string turn = ColumnText(stmt, 4);
+    h.turn_dir = (turn == "L") ? 'L' : 'R';
+    h.leg_dist_nm = ColumnDouble(stmt, 5);
+    h.leg_time_min = ColumnDouble(stmt, 6);
+    h.min_alt_ft = ColumnInt(stmt, 7);
+    // DFD uses 99999 for "no upper limit"; HoldFix uses 0 (matching X-Plane).
+    const int max_alt = ColumnInt(stmt, 8);
+    h.max_alt_ft = (max_alt >= 99999) ? 0 : max_alt;
+    h.speed_limit_kt = ColumnInt(stmt, 9);
+    data.hold_fixes.push_back(std::move(h));
+  }
+}
+
+void LoadMsa(sqlite3* conn, NavData& data) {
+  // 0=airport_identifier 1=msa_center 2=msa_center_latitude 3=msa_center_longitude
+  // 4=radius_limit 5..6=sector1(bearing,alt) 7..8=sector2 ...
+  Result<SqliteStmt> s = Prepare(conn,
+      "SELECT airport_identifier, msa_center, msa_center_latitude, "
+      "msa_center_longitude, radius_limit, "
+      "sector_bearing_1, sector_altitude_1, sector_bearing_2, sector_altitude_2, "
+      "sector_bearing_3, sector_altitude_3, sector_bearing_4, sector_altitude_4, "
+      "sector_bearing_5, sector_altitude_5 FROM tbl_airport_msa");
+  if (!s) {
+    return;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  while (Step(stmt).value_or(false)) {
+    MsaSector sector;
+    // center latitude/longitude are available but MsaSector.center is an Ident
+    // with no coordinate slot (matching X-Plane, which also discards them); the
+    // center is resolved by name from the waypoint/navaid set.
+    sector.center = Ident{ColumnText(stmt, 1), {}};
+    sector.airport_icao = ColumnText(stmt, 0);
+    const int radius = ColumnInt(stmt, 4);
+    for (int i = 0; i < 5; ++i) {
+      const int bearing = ColumnInt(stmt, 5 + i * 2);
+      const int alt = ColumnInt(stmt, 6 + i * 2);
+      if (bearing == 0 && alt == 0) {
+        break;  // unused sector slot
+      }
+      sector.arcs.push_back(MsaArc{bearing, alt, radius});
+    }
+    if (!sector.arcs.empty()) {
+      data.msa.push_back(std::move(sector));
+    }
+  }
+}
+
+void LoadGridMora(sqlite3* conn, NavData& data) {
+  // v1: starting_latitude/longitude are INTEGER. mora01..mora30 are TEXT(3) ("010"
+  // or "UNK"). Each row covers 30 one-degree cells of longitude from lon0.
+  Result<SqliteStmt> s = Prepare(conn,
+      "SELECT starting_latitude, starting_longitude, "
+      "mora01, mora02, mora03, mora04, mora05, mora06, mora07, mora08, mora09, mora10, "
+      "mora11, mora12, mora13, mora14, mora15, mora16, mora17, mora18, mora19, mora20, "
+      "mora21, mora22, mora23, mora24, mora25, mora26, mora27, mora28, mora29, mora30 "
+      "FROM tbl_grid_mora");
+  if (!s) {
+    return;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  while (Step(stmt).value_or(false)) {
+    const int lat = ColumnInt(stmt, 0);
+    const int lon0 = ColumnInt(stmt, 1);
+    for (int i = 0; i < 30; ++i) {
+      const std::string v = ColumnText(stmt, 2 + i);
+      if (v.empty() || v == "UNK") {
+        continue;
+      }
+      int value = 0;
+      try {
+        value = std::stoi(v);
+      } catch (...) {
+        continue;
+      }
+      if (value > 0) {
+        data.mora.SetCell(lat, lon0 + i, static_cast<int16_t>(value));
+      }
+    }
+  }
+}
+
+}  // namespace
+
+Result<NavData> Dfd1Loader::LoadNavData(const std::string& source_dir) const {
+  Result<std::string> db_path = FindV1Db(source_dir);
+  if (!db_path) {
+    return Result<NavData>::Err(std::move(db_path).error());
+  }
+  Result<sqlite3*> conn = AcquireConn(kLoaderName, db_path.value());
+  if (!conn) {
+    return Result<NavData>::Err(std::move(conn).error());
+  }
+  Result<void> header = CheckV1Header(conn.value());
+  if (!header) {
+    return Result<NavData>::Err(std::move(header).error());
+  }
+
+  NavData data;
+  // AIRAC cycle from tbl_header.current_airac (e.g. "2601").
+  Result<SqliteStmt> s = Prepare(conn.value(), "SELECT current_airac FROM tbl_header LIMIT 1");
+  if (s) {
+    if (Step(s.value().get()).value_or(false)) {
+      const std::string cyc = ColumnText(s.value().get(), 0);
+      try {
+        data.cycle = static_cast<uint32_t>(std::stoul(cyc));
+      } catch (...) {
+        data.cycle = 0;
+      }
+    }
+  }
+
+  std::unordered_set<Ident> seen;
+  LoadEnrouteWaypoints(conn.value(), data, seen);
+  LoadTerminalWaypoints(conn.value(), data, seen);
+  LoadVhfNavaids(conn.value(), data, seen);
+  LoadNdbNavaids(conn.value(), data, "tbl_enroute_ndbnavaids", seen);
+  LoadNdbNavaids(conn.value(), data, "tbl_terminal_ndbnavaids", seen);
+  LoadAirways(conn.value(), data);
+  LoadAirports(conn.value(), data);
+  LoadHoldings(conn.value(), data);
+  LoadMsa(conn.value(), data);
+  LoadGridMora(conn.value(), data);
+  return Result<NavData>::Ok(std::move(data));
+}
+
+namespace {
+
+// Column layout for the three procedure tables (v1), as positional indices into
+// the SELECT defined in LoadProcTable. v2 reorders/renames some columns, so
+// Dfd2Loader defines its own layout; here is v1's.
+struct ProcCols {
+  int airport = 0;    // airport_identifier
+  int proc = 1;        // procedure_identifier
+  int route_type = 2;  // route_type (numeric for SID/STAR, alpha for IAP)
+  int transition = 3;  // transition_identifier
+  int seqno = 4;       // seqno
+  int wp_ident = 5;    // waypoint_identifier
+  int wp_icao = 6;    // waypoint_icao_code
+  int path_term = 7;  // path_termination
+  int course = 8;      // magnetic_course
+  int dist_value = 9;  // route_distance_holding_distance_time (REAL)
+  int dist_flag = 10;  // distance_time (TEXT 'D'/'T'/blank)
+  int alt_desc = 11;  // altitude_description
+  int alt1 = 12;       // altitude1
+  int alt2 = 13;       // altitude2
+  int rnp = 14;        // rnp (unused; ProcedureLeg has no rnp field)
+};
+
+// Append legs/runways from one procedure table into `out` (per-airport). `type`
+// is fixed by the caller (sids->kSid, etc.). One full-table scan per table: the
+// rows are ordered by (airport, name, transition, route_type, seqno), so a
+// change in (airport, name, transition, route_type) flushes the current
+// Procedure, and a change in airport emits the previous airport's accumulated
+// CifpData. This avoids per-airport `Prepare` (~7k airports x 3 tables).
+void LoadProcTable(sqlite3* conn, const char* table, ProcedureType type,
+                   std::vector<AirportProcedureData>& out) {
+  const std::string sql = std::string(
+      "SELECT airport_identifier, procedure_identifier, route_type, "
+      "transition_identifier, seqno, waypoint_identifier, waypoint_icao_code, "
+      "path_termination, magnetic_course, route_distance_holding_distance_time, "
+      "distance_time, altitude_description, altitude1, altitude2, rnp FROM ") +
+      table + " ORDER BY airport_identifier, procedure_identifier, "
+              "transition_identifier, seqno";
+  Result<SqliteStmt> s = Prepare(conn, sql);
+  if (!s) {
+    return;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  const ProcCols c;
+
+  Procedure current;
+  current.type = type;
+  bool have_current = false;
+  std::string cur_airport, cur_name, cur_trans, cur_route;
+  CifpData cifp;  // accumulated for cur_airport
+
+  auto flush_proc = [&]() {
+    if (have_current && !current.legs.empty()) {
+      cifp.procedures.push_back(std::move(current));
+    }
+    current = Procedure{};
+    current.type = type;
+    have_current = false;
+  };
+  auto flush_airport = [&]() {
+    flush_proc();
+    if (!cifp.procedures.empty() || !cifp.runways.empty()) {
+      out.emplace_back(cur_airport, std::move(cifp));
+    }
+    cifp = CifpData{};
+  };
+
+  while (Step(stmt).value_or(false)) {
+    const std::string airport = ColumnText(stmt, c.airport);
+    const std::string name = ColumnText(stmt, c.proc);
+    const std::string trans = ColumnText(stmt, c.transition);
+    const std::string route = ColumnText(stmt, c.route_type);
+    if (airport != cur_airport) {
+      flush_airport();
+      cur_airport = airport;
+    } else if (have_current &&
+               (name != cur_name || trans != cur_trans || route != cur_route)) {
+      flush_proc();
+    }
+    if (!have_current) {
+      cur_name = name;
+      cur_trans = trans;
+      cur_route = route;
+      current.name = name;
+      current.transition_ident = trans;
+      if (trans.rfind("RW", 0) == 0) {
+        current.runway = trans;  // runway transition
+      }
+      // route_type is numeric for SID/STAR, alpha for IAP; keep numeric value as
+      // provenance, 0 when not a number. Pure provenance -- never affects routing.
+      // from_chars (no exceptions) since IAP route_type is non-numeric.
+      int rt = 0;
+      const char* d = route.data();
+      const char* e = d + route.size();
+      std::from_chars(d, e, rt);
+      current.route_type = rt;
+      have_current = true;
+    }
+    ProcedureLeg leg;
+    leg.fix = Ident(ColumnText(stmt, c.wp_ident), ColumnText(stmt, c.wp_icao));
+    leg.path_term = ParsePathTerminator(ColumnText(stmt, c.path_term));
+    leg.course_deg = ColumnDouble(stmt, c.course);  // DFD: degrees (not tenths)
+    // distance_flag 'D'=distance in nm, 'T'=time (no field for it), blank=none.
+    const std::string flag = ColumnText(stmt, c.dist_flag);
+    if (flag == "D") {
+      leg.distance_nm = ColumnDouble(stmt, c.dist_value);
+    }
+    leg.alt = ParseAltConstraint(ColumnText(stmt, c.alt_desc), ColumnInt(stmt, c.alt1),
+                                 ColumnInt(stmt, c.alt2));
+    current.legs.push_back(std::move(leg));
+  }
+  flush_airport();
+}
+
+// All runways, indexed by airport, so LoadProcedures can merge them into each
+// airport's CifpData in one pass (no per-airport query).
+std::unordered_map<std::string, std::vector<Runway>> LoadAllRunways(sqlite3* conn) {
+  std::unordered_map<std::string, std::vector<Runway>> by_airport;
+  Result<SqliteStmt> s = Prepare(conn,
+      "SELECT airport_identifier, runway_identifier, runway_latitude, "
+      "runway_longitude, landing_threshold_elevation FROM tbl_runways "
+      "ORDER BY airport_identifier");
+  if (!s) {
+    return by_airport;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  while (Step(stmt).value_or(false)) {
+    Runway rwy;
+    rwy.ident = ColumnText(stmt, 1);  // already "RW04L"-prefixed in DFD
+    rwy.threshold = Coordinate{ColumnDouble(stmt, 2), ColumnDouble(stmt, 3)};
+    rwy.elevation_ft = ColumnInt(stmt, 4);
+    by_airport[ColumnText(stmt, 0)].push_back(std::move(rwy));
+  }
+  return by_airport;
+}
+
+// Merge each airport's runways into its CifpData entry, in place. Runways go
+// only to airports that already have procedures (an airport with procedures but
+// no runways, or vice versa, is handled by the procedure scan).
+void MergeRunways(std::vector<AirportProcedureData>& out,
+                 std::unordered_map<std::string, std::vector<Runway>>& runways) {
+  for (AirportProcedureData& ap : out) {
+    auto it = runways.find(ap.first);
+    if (it != runways.end()) {
+      ap.second.runways = std::move(it->second);
+      runways.erase(it);
+    }
+  }
+  // Airports with runways but no procedures: keep them (a runway is useful as a
+  // route endpoint even without SID/STAR/approach procedures).
+  for (auto& [airport, rwys] : runways) {
+    if (!rwys.empty()) {
+      CifpData cifp;
+      cifp.runways = std::move(rwys);
+      out.emplace_back(airport, std::move(cifp));
+    }
+  }
+}
+
+// Load one airport's procedures + runways on demand (LoadProcedure path). A
+// single per-airport prepare per table is fine here: this is the on-demand path,
+// called once per airport the routing touches.
+std::optional<CifpData> LoadAirportProcedures(sqlite3* conn, const std::string& airport) {
+  CifpData cifp;
+  for (const auto& [table, type] : {std::pair{"tbl_sids", ProcedureType::kSid},
+                                     {"tbl_stars", ProcedureType::kStar},
+                                     {"tbl_iaps", ProcedureType::kApproach}}) {
+    const std::string sql = std::string(
+        "SELECT airport_identifier, procedure_identifier, route_type, "
+        "transition_identifier, seqno, waypoint_identifier, waypoint_icao_code, "
+        "path_termination, magnetic_course, route_distance_holding_distance_time, "
+        "distance_time, altitude_description, altitude1, altitude2, rnp FROM ") +
+        table + " WHERE airport_identifier = ? ORDER BY procedure_identifier, "
+                "transition_identifier, seqno";
+    Result<SqliteStmt> s = Prepare(conn, sql);
+    if (!s) {
+      continue;
+    }
+    sqlite3_stmt* stmt = s.value().get();
+    sqlite3_bind_text(stmt, 1, airport.c_str(), -1, SQLITE_TRANSIENT);
+    const ProcCols c;
+    Procedure current;
+    current.type = type;
+    bool have_current = false;
+    std::string cur_name, cur_trans, cur_route;
+    while (Step(stmt).value_or(false)) {
+      const std::string name = ColumnText(stmt, c.proc);
+      const std::string trans = ColumnText(stmt, c.transition);
+      const std::string route = ColumnText(stmt, c.route_type);
+      if (have_current && (name != cur_name || trans != cur_trans || route != cur_route)) {
+        if (!current.legs.empty()) {
+          cifp.procedures.push_back(std::move(current));
+        }
+        current = Procedure{};
+        current.type = type;
+        have_current = false;
+      }
+      if (!have_current) {
+        cur_name = name;
+        cur_trans = trans;
+        cur_route = route;
+        current.name = name;
+        current.transition_ident = trans;
+        if (trans.rfind("RW", 0) == 0) {
+          current.runway = trans;
+        }
+        int rt = 0;
+        std::from_chars(route.data(), route.data() + route.size(), rt);
+        current.route_type = rt;
+        have_current = true;
+      }
+      ProcedureLeg leg;
+      leg.fix = Ident(ColumnText(stmt, c.wp_ident), ColumnText(stmt, c.wp_icao));
+      leg.path_term = ParsePathTerminator(ColumnText(stmt, c.path_term));
+      leg.course_deg = ColumnDouble(stmt, c.course);
+      const std::string flag = ColumnText(stmt, c.dist_flag);
+      if (flag == "D") {
+        leg.distance_nm = ColumnDouble(stmt, c.dist_value);
+      }
+      leg.alt = ParseAltConstraint(ColumnText(stmt, c.alt_desc), ColumnInt(stmt, c.alt1),
+                                   ColumnInt(stmt, c.alt2));
+      current.legs.push_back(std::move(leg));
+    }
+    if (have_current && !current.legs.empty()) {
+      cifp.procedures.push_back(std::move(current));
+    }
+  }
+  // Runways for this airport.
+  Result<SqliteStmt> rs = Prepare(conn,
+      "SELECT runway_identifier, runway_latitude, runway_longitude, "
+      "landing_threshold_elevation FROM tbl_runways WHERE airport_identifier = ?");
+  if (rs) {
+    sqlite3_stmt* stmt = rs.value().get();
+    sqlite3_bind_text(stmt, 1, airport.c_str(), -1, SQLITE_TRANSIENT);
+    while (Step(stmt).value_or(false)) {
+      Runway rwy;
+      rwy.ident = ColumnText(stmt, 0);
+      rwy.threshold = Coordinate{ColumnDouble(stmt, 1), ColumnDouble(stmt, 2)};
+      rwy.elevation_ft = ColumnInt(stmt, 3);
+      cifp.runways.push_back(std::move(rwy));
+    }
+  }
+  if (cifp.procedures.empty() && cifp.runways.empty()) {
+    return std::nullopt;
+  }
+  return cifp;
+}
+
+}  // namespace
+
+Result<std::vector<AirportProcedureData>> Dfd1Loader::LoadProcedures(
+    const std::string& source_dir) const {
+  Result<std::string> db_path = FindV1Db(source_dir);
+  if (!db_path) {
+    return Result<std::vector<AirportProcedureData>>::Err(std::move(db_path).error());
+  }
+  Result<sqlite3*> conn = AcquireConn(kLoaderName, db_path.value());
+  if (!conn) {
+    return Result<std::vector<AirportProcedureData>>::Err(std::move(conn).error());
+  }
+  std::vector<AirportProcedureData> out;
+  LoadProcTable(conn.value(), "tbl_sids", ProcedureType::kSid, out);
+  LoadProcTable(conn.value(), "tbl_stars", ProcedureType::kStar, out);
+  LoadProcTable(conn.value(), "tbl_iaps", ProcedureType::kApproach, out);
+  // The three tables were scanned independently, so `out` is grouped per table,
+  // not globally ordered by airport. Sort so each airport's procedures are
+  // contiguous, then merge runways.
+  std::sort(out.begin(), out.end(),
+            [](const AirportProcedureData& a, const AirportProcedureData& b) {
+              return a.first < b.first;
+            });
+  // The same airport may appear up to three times (once per table); merge them.
+  std::vector<AirportProcedureData> merged;
+  for (AirportProcedureData& ap : out) {
+    if (!merged.empty() && merged.back().first == ap.first) {
+      auto& dst = merged.back().second.procedures;
+      auto& src = ap.second.procedures;
+      dst.insert(dst.end(), std::make_move_iterator(src.begin()),
+                  std::make_move_iterator(src.end()));
+    } else {
+      merged.push_back(std::move(ap));
+    }
+  }
+  std::unordered_map<std::string, std::vector<Runway>> runways = LoadAllRunways(conn.value());
+  MergeRunways(merged, runways);
+  return Result<std::vector<AirportProcedureData>>::Ok(std::move(merged));
+}
+
+std::optional<CifpData> Dfd1Loader::LoadProcedure(const std::string& source_dir,
+                                                   const std::string& icao) const {
+  Result<std::string> db_path = FindV1Db(source_dir);
+  if (!db_path) {
+    return std::nullopt;
+  }
+  Result<sqlite3*> conn = AcquireConn(kLoaderName, db_path.value());
+  if (!conn) {
+    return std::nullopt;
+  }
+  return LoadAirportProcedures(conn.value(), icao);
+}
+
+}  // namespace bf
+

--- a/io/loaders/dfd1/dfd1_loader.cc
+++ b/io/loaders/dfd1/dfd1_loader.cc
@@ -214,8 +214,12 @@ void LoadAirways(sqlite3* conn, NavData& data) {
       seg.direction = ParseDirection(ColumnText(stmt, 4));  // from-row direction
       seg.level = ParseAirwayLevel(ColumnText(stmt, 5));     // 'H'/'L'/'B'
       // DFD altitudes are FEET; base_fl/top_fl are flight levels (feet/100).
+      // DFD encodes "no ceiling" as maximum_altitude=99999 -> top_fl=999. That is
+      // a very high finite band, NOT the base_fl==0 && top_fl==0 "no recorded
+      // band" sentinel AltitudeBandConstraint exempts; harmless since no query
+      // cruises above FL999.
       seg.base_fl = ColumnInt(stmt, 6) / 100;
-      seg.top_fl = ColumnInt(stmt, 7) / 100;  // 99999 -> 999 (effectively unlimited)
+      seg.top_fl = ColumnInt(stmt, 7) / 100;
       data.airways.push_back(
           AirwayConnection{Ident(prev_ident, prev_icao), Ident(ident, icao), seg});
     }
@@ -329,11 +333,7 @@ void LoadGridMora(sqlite3* conn, NavData& data) {
         continue;
       }
       int value = 0;
-      try {
-        value = std::stoi(v);
-      } catch (...) {
-        continue;
-      }
+      std::from_chars(v.data(), v.data() + v.size(), value);
       if (value > 0) {
         data.mora.SetCell(lat, lon0 + i, static_cast<int16_t>(value));
       }
@@ -363,11 +363,9 @@ Result<NavData> Dfd1Loader::LoadNavData(const std::string& source_dir) const {
   if (s) {
     if (Step(s.value().get()).value_or(false)) {
       const std::string cyc = ColumnText(s.value().get(), 0);
-      try {
-        data.cycle = static_cast<uint32_t>(std::stoul(cyc));
-      } catch (...) {
-        data.cycle = 0;
-      }
+      unsigned int cycle = 0;
+      std::from_chars(cyc.data(), cyc.data() + cyc.size(), cycle);
+      data.cycle = cycle;
     }
   }
 
@@ -405,7 +403,6 @@ struct ProcCols {
   int alt_desc = 11;  // altitude_description
   int alt1 = 12;       // altitude1
   int alt2 = 13;       // altitude2
-  int rnp = 14;        // rnp (unused; ProcedureLeg has no rnp field)
 };
 
 // Append legs/runways from one procedure table into `out` (per-airport). `type`
@@ -420,7 +417,7 @@ void LoadProcTable(sqlite3* conn, const char* table, ProcedureType type,
       "SELECT airport_identifier, procedure_identifier, route_type, "
       "transition_identifier, seqno, waypoint_identifier, waypoint_icao_code, "
       "path_termination, magnetic_course, route_distance_holding_distance_time, "
-      "distance_time, altitude_description, altitude1, altitude2, rnp FROM ") +
+      "distance_time, altitude_description, altitude1, altitude2 FROM ") +
       table + " ORDER BY airport_identifier, procedure_identifier, "
               "transition_identifier, seqno";
   Result<SqliteStmt> s = Prepare(conn, sql);
@@ -556,7 +553,7 @@ std::optional<CifpData> LoadAirportProcedures(sqlite3* conn, const std::string& 
         "SELECT airport_identifier, procedure_identifier, route_type, "
         "transition_identifier, seqno, waypoint_identifier, waypoint_icao_code, "
         "path_termination, magnetic_course, route_distance_holding_distance_time, "
-        "distance_time, altitude_description, altitude1, altitude2, rnp FROM ") +
+        "distance_time, altitude_description, altitude1, altitude2 FROM ") +
         table + " WHERE airport_identifier = ? ORDER BY procedure_identifier, "
                 "transition_identifier, seqno";
     Result<SqliteStmt> s = Prepare(conn, sql);

--- a/io/loaders/dfd1/dfd1_loader.h
+++ b/io/loaders/dfd1/dfd1_loader.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "io/loaders/loader.h"
+
+namespace bf {
+
+// DFD v1.0 SQLite loader. Parses the "Data File Definition v1.0" SQLite format
+// (RealTraffic / SimToolkitPro / PMDG MSFS 737/777 `navdb.s3db`,
+// `navdata.s3db`, or `e_dfd_PMDG.s3db` -- byte-identical copies of the same
+// Jeppesen dataset) into the same NavData / CifpData domain types as
+// XPlane12Loader. Read-only; thread-safe (the underlying SQLite connection is
+// held per-thread, never shared -- see sqlite_util).
+//
+// `source_dir` points at the directory containing the .s3db file. The loader
+// searches for navdb.s3db -> navdata.s3db -> e_dfd_PMDG.s3db -> first *.s3db.
+class Dfd1Loader final : public Loader {
+ public:
+  Result<NavData> LoadNavData(const std::string& source_dir) const override;
+  Result<std::vector<AirportProcedureData>> LoadProcedures(
+      const std::string& source_dir) const override;
+  std::optional<CifpData> LoadProcedure(const std::string& source_dir,
+                                        const std::string& icao) const override;
+  std::string name() const override { return "dfd1"; }
+};
+
+}  // namespace bf

--- a/io/loaders/dfd2/dfd2_loader.cc
+++ b/io/loaders/dfd2/dfd2_loader.cc
@@ -1,0 +1,752 @@
+#include "io/loaders/dfd2/dfd2_loader.h"
+
+#include <algorithm>
+#include <charconv>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+#include <sqlite3.h>
+
+#include "core/domain/airway.h"
+#include "core/domain/airport.h"
+#include "core/domain/hold_fix.h"
+#include "core/domain/ident.h"
+#include "core/domain/mora_grid.h"
+#include "core/domain/msa.h"
+#include "core/domain/navaid_detail.h"
+#include "core/domain/procedure.h"
+#include "core/domain/waypoint.h"
+#include "core/result.h"
+#include "io/loaders/sqlite_util.h"
+#include "io/nav_data.h"
+
+namespace bf {
+namespace {
+
+// DFD v2 source loader. Mirrors Dfd1Loader's structure; differences from v1.0
+// (table-name prefixes, column renames, swapped distance columns, course_flag,
+// MORA quadrant) are isolated here. See the loader plan for the full diff.
+
+constexpr std::string_view kLoaderName = "dfd2";
+
+// v2 table names -- prefixes are NOT a fixed pattern (tbl_d_vhfnavaids is a
+// single letter), so they are listed explicitly.
+constexpr std::string_view kTblHeader = "tbl_hdr_header";
+constexpr std::string_view kTblAirports = "tbl_pa_airports";
+constexpr std::string_view kTblRunways = "tbl_pg_runways";
+constexpr std::string_view kTblEnrouteWp = "tbl_ea_enroute_waypoints";
+constexpr std::string_view kTblTerminalWp = "tbl_pc_terminal_waypoints";
+constexpr std::string_view kTblVhf = "tbl_d_vhfnavaids";
+constexpr std::string_view kTblEnrouteNdb = "tbl_db_enroute_ndbnavaids";
+constexpr std::string_view kTblTerminalNdb = "tbl_pn_terminal_ndbnavaids";
+constexpr std::string_view kTblAirways = "tbl_er_enroute_airways";
+constexpr std::string_view kTblSids = "tbl_pd_sids";
+constexpr std::string_view kTblStars = "tbl_pe_stars";
+constexpr std::string_view kTblIaps = "tbl_pf_iaps";
+constexpr std::string_view kTblHoldings = "tbl_ep_holdings";
+constexpr std::string_view kTblMsa = "tbl_ps_airport_msa";
+constexpr std::string_view kTblGridMora = "tbl_as_grid_mora";
+
+Result<std::string> FindV2Db(const std::string& source_dir) {
+  namespace fs = std::filesystem;
+  std::error_code ec;
+  if (!fs::is_directory(source_dir, ec)) {
+    return Result<std::string>::Err(
+        Error(ErrorCode::kDataMissing, "source directory not found: " + source_dir));
+  }
+  fs::path preferred = fs::path(source_dir) / "db.s3db";
+  if (fs::exists(preferred, ec)) {
+    return Result<std::string>::Ok(preferred.string());
+  }
+  for (const fs::directory_entry& de : fs::directory_iterator(source_dir, ec)) {
+    if (de.is_regular_file() && de.path().extension() == ".s3db") {
+      return Result<std::string>::Ok(de.path().string());
+    }
+  }
+  return Result<std::string>::Err(
+      Error(ErrorCode::kDataMissing, "no DFD v2 .s3db under " + source_dir));
+}
+
+// Verify the DB is DFD v2 (tbl_hdr_header.dataset == "NG_FWDFD"). A missing
+// tbl_hdr_header (Prepare fails or no row) or a different dataset means the user
+// likely pointed dfd2 at a v1 DB; give an actionable message.
+Result<void> CheckV2Header(sqlite3* conn) {
+  const std::string sql =
+      std::string("SELECT dataset FROM ") + std::string(kTblHeader) + " LIMIT 1";
+  Result<SqliteStmt> stmt = Prepare(conn, sql);
+  std::string dataset;
+  if (stmt) {
+    Result<bool> row = Step(stmt.value().get());
+    if (row && row.value()) {
+      dataset = ColumnText(stmt.value().get(), 0);
+    }
+  }
+  if (dataset != "NG_FWDFD") {
+    return Result<void>::Err(Error(ErrorCode::kInvalidArgument,
+        "not a DFD v2 database (tbl_hdr_header missing or wrong dataset); "
+        "for DFD v1 use --loader dfd1"));
+  }
+  return Result<void>::Ok();
+}
+
+// Map a DFD navaid_class first character to a routable WaypointKind (same as v1).
+WaypointKind NavaidKindFromClass(const std::string& cls) {
+  if (cls.empty()) {
+    return WaypointKind::kOther;
+  }
+  switch (cls[0]) {
+    case 'V':
+      return WaypointKind::kVor;
+    case 'D':
+    case 'T':
+    case 'M':
+      return WaypointKind::kDme;
+    default:
+      return WaypointKind::kOther;  // I/N/P or space-padded ILS component
+  }
+}
+
+// Parse a v2 MORA starting coordinate: VarChar like "N07"/"S90"/"W090"/"E179"
+// -> signed integer degrees.
+int ParseHemiCoord(const std::string& s) {
+  if (s.size() < 2) {
+    return 0;
+  }
+  const char hemi = s[0];
+  int value = 0;
+  std::from_chars(s.data() + 1, s.data() + s.size(), value);
+  if (hemi == 'S' || hemi == 'W') {
+    return -value;
+  }
+  return value;  // N or E
+}
+
+// --- Per-table loaders (column names that differ from v1 are noted). ---
+
+void LoadEnrouteWaypoints(sqlite3* conn, NavData& data, std::unordered_set<Ident>& seen) {
+  const std::string sql = std::string("SELECT icao_code, waypoint_identifier, "
+                                      "waypoint_latitude, waypoint_longitude FROM ") +
+                          std::string(kTblEnrouteWp);
+  Result<SqliteStmt> s = Prepare(conn, sql);
+  if (!s) {
+    return;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  while (Step(stmt).value_or(false)) {
+    const Ident key(ColumnText(stmt, 1), ColumnText(stmt, 0));
+    if (seen.insert(key).second) {
+      data.waypoints.push_back(
+          Waypoint{key, Coordinate{ColumnDouble(stmt, 2), ColumnDouble(stmt, 3)}, WaypointKind::kFix});
+    }
+  }
+}
+
+void LoadTerminalWaypoints(sqlite3* conn, NavData& data, std::unordered_set<Ident>& seen) {
+  const std::string sql = std::string("SELECT region_code, waypoint_identifier, "
+                                      "waypoint_latitude, waypoint_longitude FROM ") +
+                          std::string(kTblTerminalWp);
+  Result<SqliteStmt> s = Prepare(conn, sql);
+  if (!s) {
+    return;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  while (Step(stmt).value_or(false)) {
+    const Ident key(ColumnText(stmt, 1), ColumnText(stmt, 0));
+    if (seen.insert(key).second) {
+      data.waypoints.push_back(
+          Waypoint{key, Coordinate{ColumnDouble(stmt, 2), ColumnDouble(stmt, 3)}, WaypointKind::kFix});
+    }
+  }
+}
+
+void LoadVhfNavaids(sqlite3* conn, NavData& data, std::unordered_set<Ident>& seen) {
+  // v2: navaid_identifier / navaid_latitude / navaid_longitude / navaid_frequency
+  // (v1 used vor_*).
+  const std::string sql =
+      std::string("SELECT icao_code, navaid_identifier, navaid_frequency, navaid_class, "
+                  "range, station_declination, dme_elevation, navaid_latitude, "
+                  "navaid_longitude FROM ") + std::string(kTblVhf);
+  Result<SqliteStmt> s = Prepare(conn, sql);
+  if (!s) {
+    return;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  while (Step(stmt).value_or(false)) {
+    const WaypointKind kind = NavaidKindFromClass(ColumnText(stmt, 3));
+    if (kind == WaypointKind::kOther) {
+      continue;  // ILS/LOC component: not enroute-routable
+    }
+    const Ident key(ColumnText(stmt, 1), ColumnText(stmt, 0));
+    if (!seen.insert(key).second) {
+      continue;
+    }
+    data.waypoints.push_back(
+        Waypoint{key, Coordinate{ColumnDouble(stmt, 7), ColumnDouble(stmt, 8)}, kind});
+    const int freq_raw = static_cast<int>(std::lround(ColumnDouble(stmt, 2) * 100.0));
+    data.navaid_details.push_back(NavaidDetail{
+        key, kind, ColumnInt(stmt, 6), freq_raw, ColumnDouble(stmt, 4), ColumnDouble(stmt, 5)});
+  }
+}
+
+void LoadNdbNavaids(sqlite3* conn, NavData& data, std::string_view table,
+                    std::unordered_set<Ident>& seen) {
+  // v2: navaid_identifier / navaid_frequency / navaid_latitude / navaid_longitude
+  // (v1 used ndb_*).
+  const std::string sql =
+      std::string("SELECT icao_code, navaid_identifier, navaid_frequency, range, "
+                  "navaid_latitude, navaid_longitude FROM ") +
+      std::string(table);
+  Result<SqliteStmt> s = Prepare(conn, sql);
+  if (!s) {
+    return;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  while (Step(stmt).value_or(false)) {
+    const Ident key(ColumnText(stmt, 1), ColumnText(stmt, 0));
+    if (!seen.insert(key).second) {
+      continue;
+    }
+    data.waypoints.push_back(
+        Waypoint{key, Coordinate{ColumnDouble(stmt, 4), ColumnDouble(stmt, 5)}, WaypointKind::kNdb});
+    data.navaid_details.push_back(NavaidDetail{
+        key, WaypointKind::kNdb, 0, ColumnInt(stmt, 2), ColumnDouble(stmt, 3), 0.0});
+  }
+}
+
+void LoadAirways(sqlite3* conn, NavData& data) {
+  // Column names are the same as v1; only the table name differs.
+  const std::string sql = std::string(
+      "SELECT route_identifier, seqno, waypoint_identifier, icao_code, "
+      "direction_restriction, flightlevel, minimum_altitude1, maximum_altitude, "
+      "outbound_course, inbound_course FROM ") + std::string(kTblAirways) +
+      " ORDER BY route_identifier, seqno";
+  Result<SqliteStmt> s = Prepare(conn, sql);
+  if (!s) {
+    return;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  bool have_prev = false;
+  std::string prev_route, prev_ident, prev_icao;
+  AirwaySegment seg;
+  while (Step(stmt).value_or(false)) {
+    const std::string route = ColumnText(stmt, 0);
+    const std::string ident = ColumnText(stmt, 2);
+    const std::string icao = ColumnText(stmt, 3);
+    if (have_prev && route == prev_route) {
+      seg.name = prev_route;
+      seg.direction = ParseDirection(ColumnText(stmt, 4));
+      seg.level = ParseAirwayLevel(ColumnText(stmt, 5));
+      seg.base_fl = ColumnInt(stmt, 6) / 100;  // feet -> flight level
+      seg.top_fl = ColumnInt(stmt, 7) / 100;
+      data.airways.push_back(
+          AirwayConnection{Ident(prev_ident, prev_icao), Ident(ident, icao), seg});
+    }
+    prev_route = route;
+    prev_ident = ident;
+    prev_icao = icao;
+    have_prev = true;
+  }
+}
+
+void LoadAirports(sqlite3* conn, NavData& data) {
+  const std::string sql = std::string("SELECT icao_code, airport_identifier, "
+                                      "airport_ref_latitude, airport_ref_longitude, elevation FROM ") +
+                          std::string(kTblAirports);
+  Result<SqliteStmt> s = Prepare(conn, sql);
+  if (!s) {
+    return;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  while (Step(stmt).value_or(false)) {
+    data.airports.push_back(Airport{ColumnText(stmt, 1), ColumnText(stmt, 0),
+                                   Coordinate{ColumnDouble(stmt, 2), ColumnDouble(stmt, 3)},
+                                   ColumnInt(stmt, 4)});
+  }
+}
+
+// Airport magnetic variation by ICAO, for converting course_flag='T' (true
+// course) legs to magnetic. Read by the procedure loaders only.
+std::unordered_map<std::string, double> LoadAirportMagvars(sqlite3* conn) {
+  std::unordered_map<std::string, double> out;
+  const std::string sql =
+      std::string("SELECT airport_identifier, magnetic_variation FROM ") + std::string(kTblAirports);
+  Result<SqliteStmt> s = Prepare(conn, sql);
+  if (!s) {
+    return out;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  while (Step(stmt).value_or(false)) {
+    out[ColumnText(stmt, 0)] = ColumnDouble(stmt, 1);
+  }
+  return out;
+}
+
+void LoadHoldings(sqlite3* conn, NavData& data) {
+  const std::string sql = std::string(
+      "SELECT region_code, icao_code, waypoint_identifier, inbound_holding_course, "
+      "turn_direction, leg_length, leg_time, minimum_altitude, maximum_altitude, "
+      "holding_speed FROM ") + std::string(kTblHoldings);
+  Result<SqliteStmt> s = Prepare(conn, sql);
+  if (!s) {
+    return;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  while (Step(stmt).value_or(false)) {
+    HoldFix h;
+    h.fix = Ident(ColumnText(stmt, 2), ColumnText(stmt, 1));
+    h.airport_icao = ColumnText(stmt, 0);
+    h.inbound_course = ColumnDouble(stmt, 3);
+    const std::string turn = ColumnText(stmt, 4);
+    h.turn_dir = (turn == "L") ? 'L' : 'R';
+    h.leg_dist_nm = ColumnDouble(stmt, 5);
+    h.leg_time_min = ColumnDouble(stmt, 6);
+    h.min_alt_ft = ColumnInt(stmt, 7);
+    const int max_alt = ColumnInt(stmt, 8);
+    h.max_alt_ft = (max_alt >= 99999) ? 0 : max_alt;
+    h.speed_limit_kt = ColumnInt(stmt, 9);
+    data.hold_fixes.push_back(std::move(h));
+  }
+}
+
+void LoadMsa(sqlite3* conn, NavData& data) {
+  const std::string sql = std::string(
+      "SELECT airport_identifier, msa_center, radius_limit, "
+      "sector_bearing_1, sector_altitude_1, sector_bearing_2, sector_altitude_2, "
+      "sector_bearing_3, sector_altitude_3, sector_bearing_4, sector_altitude_4, "
+      "sector_bearing_5, sector_altitude_5 FROM ") + std::string(kTblMsa);
+  Result<SqliteStmt> s = Prepare(conn, sql);
+  if (!s) {
+    return;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  while (Step(stmt).value_or(false)) {
+    MsaSector sector;
+    sector.center = Ident{ColumnText(stmt, 1), {}};
+    sector.airport_icao = ColumnText(stmt, 0);
+    const int radius = ColumnInt(stmt, 2);
+    for (int i = 0; i < 5; ++i) {
+      const int bearing = ColumnInt(stmt, 3 + i * 2);
+      const int alt = ColumnInt(stmt, 4 + i * 2);
+      if (bearing == 0 && alt == 0) {
+        break;
+      }
+      sector.arcs.push_back(MsaArc{bearing, alt, radius});
+    }
+    if (!sector.arcs.empty()) {
+      data.msa.push_back(std::move(sector));
+    }
+  }
+}
+
+void LoadGridMora(sqlite3* conn, NavData& data) {
+  // v2: quadrant_code subdivides each 1-degree cell into 4; the blank-quadrant row
+  // already carries the full 1-degree value (verified), so we take only those and
+  // skip A/B/C/D (the 1-degree MoraGrid cannot store the 30-min offset). Starting
+  // coords are VarChar "N07"/"W090", unlike v1's INTEGER.
+  const std::string sql = std::string(
+      "SELECT starting_latitude, starting_longitude, quadrant_code, "
+      "mora01, mora02, mora03, mora04, mora05, mora06, mora07, mora08, mora09, mora10, "
+      "mora11, mora12, mora13, mora14, mora15, mora16, mora17, mora18, mora19, mora20, "
+      "mora21, mora22, mora23, mora24, mora25, mora26, mora27, mora28, mora29, mora30 "
+      "FROM ") + std::string(kTblGridMora);
+  Result<SqliteStmt> s = Prepare(conn, sql);
+  if (!s) {
+    return;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  while (Step(stmt).value_or(false)) {
+    const std::string q = ColumnText(stmt, 2);
+    if (!q.empty()) {
+      continue;  // A/B/C/D quadrant: skip (blank row covers this cell at 1 degree)
+    }
+    const int lat = ParseHemiCoord(ColumnText(stmt, 0));
+    const int lon0 = ParseHemiCoord(ColumnText(stmt, 1));
+    for (int i = 0; i < 30; ++i) {
+      const std::string v = ColumnText(stmt, 3 + i);
+      if (v.empty() || v == "UNK") {
+        continue;
+      }
+      int value = 0;
+      std::from_chars(v.data(), v.data() + v.size(), value);
+      if (value > 0) {
+        data.mora.SetCell(lat, lon0 + i, static_cast<int16_t>(value));
+      }
+    }
+  }
+}
+
+// Convert a true course to magnetic using the airport's magnetic variation.
+// magnetic = true - variation (variation: west negative, so magnetic > true west).
+double ToMagnetic(double true_course, double magvar) {
+  double mag = true_course - magvar;
+  while (mag < 0.0) {
+    mag += 360.0;
+  }
+  while (mag >= 360.0) {
+    mag -= 360.0;
+  }
+  return mag;
+}
+
+// v2 procedure column layout (differs from v1: course+course_flag, swapped
+// distance value/flag columns).
+struct ProcCols {
+  int airport = 0;    // airport_identifier
+  int proc = 1;        // procedure_identifier
+  int route_type = 2;  // route_type
+  int transition = 3;  // transition_identifier
+  int seqno = 4;       // seqno
+  int wp_ident = 5;    // waypoint_identifier
+  int wp_icao = 6;    // waypoint_icao_code
+  int path_term = 7;  // path_termination
+  int course = 8;      // course (REAL)
+  int course_flag = 9;  // course_flag ('M'/'T')
+  int dist_value = 10;  // distance_time (REAL value -- swapped vs v1!)
+  int dist_flag = 11;  // route_distance_holding_distance_time (flag -- swapped!)
+  int alt_desc = 12;  // altitude_description
+  int alt1 = 13;       // altitude1
+  int alt2 = 14;       // altitude2
+};
+
+// SQL for one procedure table, in ProcCols column order.
+std::string ProcSql(std::string_view table, bool single_airport) {
+  std::string sql = std::string(
+      "SELECT airport_identifier, procedure_identifier, route_type, "
+      "transition_identifier, seqno, waypoint_identifier, waypoint_icao_code, "
+      "path_termination, course, course_flag, distance_time, "
+      "route_distance_holding_distance_time, altitude_description, altitude1, "
+      "altitude2 FROM ") + std::string(table);
+  if (single_airport) {
+    sql += " WHERE airport_identifier = ?";
+  }
+  sql += " ORDER BY airport_identifier, procedure_identifier, transition_identifier, seqno";
+  return sql;
+}
+
+// Emit one Procedure leg from a row. `magvar` converts true courses (course_flag
+// 'T'); magnetic courses ('M'/blank) are used as-is.
+void AppendLeg(sqlite3_stmt* stmt, const ProcCols& c, double magvar, Procedure& proc) {
+  ProcedureLeg leg;
+  leg.fix = Ident(ColumnText(stmt, c.wp_ident), ColumnText(stmt, c.wp_icao));
+  leg.path_term = ParsePathTerminator(ColumnText(stmt, c.path_term));
+  const double course = ColumnDouble(stmt, c.course);
+  const std::string flag = ColumnText(stmt, c.course_flag);
+  leg.course_deg = (flag == "T") ? ToMagnetic(course, magvar) : course;
+  // v2 distance: distance_time holds the value, route_distance_... holds the flag.
+  const std::string dflag = ColumnText(stmt, c.dist_flag);
+  if (dflag == "D") {
+    leg.distance_nm = ColumnDouble(stmt, c.dist_value);
+  }
+  leg.alt = ParseAltConstraint(ColumnText(stmt, c.alt_desc), ColumnInt(stmt, c.alt1),
+                               ColumnInt(stmt, c.alt2));
+  proc.legs.push_back(std::move(leg));
+}
+
+// Full-table scan appending per-airport procedures into `out`. magvar_by_airport
+// supplies the true->magnetic conversion for course_flag='T' legs.
+void LoadProcTable(sqlite3* conn, std::string_view table, ProcedureType type,
+                   const std::unordered_map<std::string, double>& magvar_by_airport,
+                   std::vector<AirportProcedureData>& out) {
+  Result<SqliteStmt> s = Prepare(conn, ProcSql(table, /*single_airport=*/false));
+  if (!s) {
+    return;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  const ProcCols c;
+
+  Procedure current;
+  current.type = type;
+  bool have_current = false;
+  std::string cur_airport, cur_name, cur_trans, cur_route;
+  CifpData cifp;
+  double magvar = 0.0;
+
+  auto flush_proc = [&]() {
+    if (have_current && !current.legs.empty()) {
+      cifp.procedures.push_back(std::move(current));
+    }
+    current = Procedure{};
+    current.type = type;
+    have_current = false;
+  };
+  auto flush_airport = [&]() {
+    flush_proc();
+    if (!cifp.procedures.empty() || !cifp.runways.empty()) {
+      out.emplace_back(cur_airport, std::move(cifp));
+    }
+    cifp = CifpData{};
+  };
+
+  while (Step(stmt).value_or(false)) {
+    const std::string airport = ColumnText(stmt, c.airport);
+    const std::string name = ColumnText(stmt, c.proc);
+    const std::string trans = ColumnText(stmt, c.transition);
+    const std::string route = ColumnText(stmt, c.route_type);
+    if (airport != cur_airport) {
+      flush_airport();
+      cur_airport = airport;
+      if (auto it = magvar_by_airport.find(airport); it != magvar_by_airport.end()) {
+        magvar = it->second;
+      } else {
+        magvar = 0.0;
+      }
+    } else if (have_current &&
+               (name != cur_name || trans != cur_trans || route != cur_route)) {
+      flush_proc();
+    }
+    if (!have_current) {
+      cur_name = name;
+      cur_trans = trans;
+      cur_route = route;
+      current.name = name;
+      current.transition_ident = trans;
+      if (trans.rfind("RW", 0) == 0) {
+        current.runway = trans;
+      }
+      int rt = 0;
+      std::from_chars(route.data(), route.data() + route.size(), rt);
+      current.route_type = rt;
+      have_current = true;
+    }
+    AppendLeg(stmt, c, magvar, current);
+  }
+  flush_airport();
+}
+
+std::unordered_map<std::string, std::vector<Runway>> LoadAllRunways(sqlite3* conn) {
+  std::unordered_map<std::string, std::vector<Runway>> by_airport;
+  const std::string sql = std::string(
+      "SELECT airport_identifier, runway_identifier, runway_latitude, "
+      "runway_longitude, landing_threshold_elevation FROM ") + std::string(kTblRunways) +
+      " ORDER BY airport_identifier";
+  Result<SqliteStmt> s = Prepare(conn, sql);
+  if (!s) {
+    return by_airport;
+  }
+  sqlite3_stmt* stmt = s.value().get();
+  while (Step(stmt).value_or(false)) {
+    Runway rwy;
+    rwy.ident = ColumnText(stmt, 1);
+    rwy.threshold = Coordinate{ColumnDouble(stmt, 2), ColumnDouble(stmt, 3)};
+    rwy.elevation_ft = ColumnInt(stmt, 4);
+    by_airport[ColumnText(stmt, 0)].push_back(std::move(rwy));
+  }
+  return by_airport;
+}
+
+void MergeRunways(std::vector<AirportProcedureData>& out,
+                  std::unordered_map<std::string, std::vector<Runway>>& runways) {
+  for (AirportProcedureData& ap : out) {
+    auto it = runways.find(ap.first);
+    if (it != runways.end()) {
+      ap.second.runways = std::move(it->second);
+      runways.erase(it);
+    }
+  }
+  for (auto& [airport, rwys] : runways) {
+    if (!rwys.empty()) {
+      CifpData cifp;
+      cifp.runways = std::move(rwys);
+      out.emplace_back(airport, std::move(cifp));
+    }
+  }
+}
+
+// Load one airport on demand (LoadProcedure path).
+std::optional<CifpData> LoadAirportProcedures(
+    sqlite3* conn, const std::string& airport,
+    const std::unordered_map<std::string, double>& magvar_by_airport) {
+  double magvar = 0.0;
+  if (auto it = magvar_by_airport.find(airport); it != magvar_by_airport.end()) {
+    magvar = it->second;
+  }
+  CifpData cifp;
+  const std::pair<std::string_view, ProcedureType> kTables[] = {
+      {kTblSids, ProcedureType::kSid},
+      {kTblStars, ProcedureType::kStar},
+      {kTblIaps, ProcedureType::kApproach},
+  };
+  for (const auto& [table, type] : kTables) {
+    Result<SqliteStmt> s = Prepare(conn, ProcSql(table, /*single_airport=*/true));
+    if (!s) {
+      continue;
+    }
+    sqlite3_stmt* stmt = s.value().get();
+    sqlite3_bind_text(stmt, 1, airport.c_str(), -1, SQLITE_TRANSIENT);
+    const ProcCols c;
+    Procedure current;
+    current.type = type;
+    bool have_current = false;
+    std::string cur_name, cur_trans, cur_route;
+    while (Step(stmt).value_or(false)) {
+      const std::string name = ColumnText(stmt, c.proc);
+      const std::string trans = ColumnText(stmt, c.transition);
+      const std::string route = ColumnText(stmt, c.route_type);
+      if (have_current && (name != cur_name || trans != cur_trans || route != cur_route)) {
+        if (!current.legs.empty()) {
+          cifp.procedures.push_back(std::move(current));
+        }
+        current = Procedure{};
+        current.type = type;
+        have_current = false;
+      }
+      if (!have_current) {
+        cur_name = name;
+        cur_trans = trans;
+        cur_route = route;
+        current.name = name;
+        current.transition_ident = trans;
+        if (trans.rfind("RW", 0) == 0) {
+          current.runway = trans;
+        }
+        int rt = 0;
+        std::from_chars(route.data(), route.data() + route.size(), rt);
+        current.route_type = rt;
+        have_current = true;
+      }
+      AppendLeg(stmt, c, magvar, current);
+    }
+    if (have_current && !current.legs.empty()) {
+      cifp.procedures.push_back(std::move(current));
+    }
+  }
+  Result<SqliteStmt> rs = Prepare(conn, std::string(
+      "SELECT runway_identifier, runway_latitude, runway_longitude, "
+      "landing_threshold_elevation FROM ") + std::string(kTblRunways) +
+      " WHERE airport_identifier = ?");
+  if (rs) {
+    sqlite3_stmt* stmt = rs.value().get();
+    sqlite3_bind_text(stmt, 1, airport.c_str(), -1, SQLITE_TRANSIENT);
+    while (Step(stmt).value_or(false)) {
+      Runway rwy;
+      rwy.ident = ColumnText(stmt, 0);
+      rwy.threshold = Coordinate{ColumnDouble(stmt, 1), ColumnDouble(stmt, 2)};
+      rwy.elevation_ft = ColumnInt(stmt, 3);
+      cifp.runways.push_back(std::move(rwy));
+    }
+  }
+  if (cifp.procedures.empty() && cifp.runways.empty()) {
+    return std::nullopt;
+  }
+  return cifp;
+}
+
+}  // namespace
+
+Result<NavData> Dfd2Loader::LoadNavData(const std::string& source_dir) const {
+  Result<std::string> db_path = FindV2Db(source_dir);
+  if (!db_path) {
+    return Result<NavData>::Err(std::move(db_path).error());
+  }
+  Result<sqlite3*> conn = AcquireConn(kLoaderName, db_path.value());
+  if (!conn) {
+    return Result<NavData>::Err(std::move(conn).error());
+  }
+  Result<void> header = CheckV2Header(conn.value());
+  if (!header) {
+    return Result<NavData>::Err(std::move(header).error());
+  }
+
+  NavData data;
+  // AIRAC cycle from tbl_hdr_header.cycle (e.g. "2601").
+  const std::string cycle_sql = std::string("SELECT cycle FROM ") + std::string(kTblHeader) + " LIMIT 1";
+  Result<SqliteStmt> s = Prepare(conn.value(), cycle_sql);
+  if (s) {
+    if (Step(s.value().get()).value_or(false)) {
+      const std::string cyc = ColumnText(s.value().get(), 0);
+      try {
+        data.cycle = static_cast<uint32_t>(std::stoul(cyc));
+      } catch (...) {
+        data.cycle = 0;
+      }
+    }
+  }
+
+  std::unordered_set<Ident> seen;
+  LoadEnrouteWaypoints(conn.value(), data, seen);
+  LoadTerminalWaypoints(conn.value(), data, seen);
+  LoadVhfNavaids(conn.value(), data, seen);
+  LoadNdbNavaids(conn.value(), data, kTblEnrouteNdb, seen);
+  LoadNdbNavaids(conn.value(), data, kTblTerminalNdb, seen);
+  LoadAirways(conn.value(), data);
+  LoadAirports(conn.value(), data);
+  LoadHoldings(conn.value(), data);
+  LoadMsa(conn.value(), data);
+  LoadGridMora(conn.value(), data);
+  return Result<NavData>::Ok(std::move(data));
+}
+
+}  // namespace bf
+
+namespace bf {
+
+Result<std::vector<AirportProcedureData>> Dfd2Loader::LoadProcedures(
+    const std::string& source_dir) const {
+  Result<std::string> db_path = FindV2Db(source_dir);
+  if (!db_path) {
+    return Result<std::vector<AirportProcedureData>>::Err(std::move(db_path).error());
+  }
+  Result<sqlite3*> conn = AcquireConn(kLoaderName, db_path.value());
+  if (!conn) {
+    return Result<std::vector<AirportProcedureData>>::Err(std::move(conn).error());
+  }
+  // magvar is needed for course_flag='T' legs; read just the (airport, magvar)
+  // pairs rather than re-running the full airports load.
+  std::unordered_map<std::string, double> magvar = LoadAirportMagvars(conn.value());
+
+  std::vector<AirportProcedureData> out;
+  LoadProcTable(conn.value(), kTblSids, ProcedureType::kSid, magvar, out);
+  LoadProcTable(conn.value(), kTblStars, ProcedureType::kStar, magvar, out);
+  LoadProcTable(conn.value(), kTblIaps, ProcedureType::kApproach, magvar, out);
+  std::sort(out.begin(), out.end(),
+            [](const AirportProcedureData& a, const AirportProcedureData& b) {
+              return a.first < b.first;
+            });
+  std::vector<AirportProcedureData> merged;
+  for (AirportProcedureData& ap : out) {
+    if (!merged.empty() && merged.back().first == ap.first) {
+      auto& dst = merged.back().second.procedures;
+      auto& src = ap.second.procedures;
+      dst.insert(dst.end(), std::make_move_iterator(src.begin()),
+                  std::make_move_iterator(src.end()));
+    } else {
+      merged.push_back(std::move(ap));
+    }
+  }
+  auto runways = LoadAllRunways(conn.value());
+  MergeRunways(merged, runways);
+  return Result<std::vector<AirportProcedureData>>::Ok(std::move(merged));
+}
+
+std::optional<CifpData> Dfd2Loader::LoadProcedure(const std::string& source_dir,
+                                                   const std::string& icao) const {
+  Result<std::string> db_path = FindV2Db(source_dir);
+  if (!db_path) {
+    return std::nullopt;
+  }
+  Result<sqlite3*> conn = AcquireConn(kLoaderName, db_path.value());
+  if (!conn) {
+    return std::nullopt;
+  }
+  // On-demand: read just this airport's magvar (one row) rather than the whole
+  // airports table.
+  std::unordered_map<std::string, double> magvar;
+  Result<SqliteStmt> ms = Prepare(conn.value(),
+      std::string("SELECT airport_identifier, magnetic_variation FROM ") +
+          std::string(kTblAirports) + " WHERE airport_identifier = ?");
+  if (ms) {
+    sqlite3_stmt* stmt = ms.value().get();
+    sqlite3_bind_text(stmt, 1, icao.c_str(), -1, SQLITE_TRANSIENT);
+    if (Step(stmt).value_or(false)) {
+      magvar[ColumnText(stmt, 0)] = ColumnDouble(stmt, 1);
+    }
+  }
+  return LoadAirportProcedures(conn.value(), icao, magvar);
+}
+
+}  // namespace bf

--- a/io/loaders/dfd2/dfd2_loader.cc
+++ b/io/loaders/dfd2/dfd2_loader.cc
@@ -242,6 +242,9 @@ void LoadAirways(sqlite3* conn, NavData& data) {
       seg.direction = ParseDirection(ColumnText(stmt, 4));
       seg.level = ParseAirwayLevel(ColumnText(stmt, 5));
       seg.base_fl = ColumnInt(stmt, 6) / 100;  // feet -> flight level
+      // 99999 ("no ceiling") -> 999: a very high finite band, not the
+      // base_fl==0 && top_fl==0 sentinel AltitudeBandConstraint exempts. Harmless
+      // since no query cruises above FL999. (Same as dfd1.)
       seg.top_fl = ColumnInt(stmt, 7) / 100;
       data.airways.push_back(
           AirwayConnection{Ident(prev_ident, prev_icao), Ident(ident, icao), seg});
@@ -659,11 +662,9 @@ Result<NavData> Dfd2Loader::LoadNavData(const std::string& source_dir) const {
   if (s) {
     if (Step(s.value().get()).value_or(false)) {
       const std::string cyc = ColumnText(s.value().get(), 0);
-      try {
-        data.cycle = static_cast<uint32_t>(std::stoul(cyc));
-      } catch (...) {
-        data.cycle = 0;
-      }
+      unsigned int cycle = 0;
+      std::from_chars(cyc.data(), cyc.data() + cyc.size(), cycle);
+      data.cycle = cycle;
     }
   }
 
@@ -680,10 +681,6 @@ Result<NavData> Dfd2Loader::LoadNavData(const std::string& source_dir) const {
   LoadGridMora(conn.value(), data);
   return Result<NavData>::Ok(std::move(data));
 }
-
-}  // namespace bf
-
-namespace bf {
 
 Result<std::vector<AirportProcedureData>> Dfd2Loader::LoadProcedures(
     const std::string& source_dir) const {

--- a/io/loaders/dfd2/dfd2_loader.cc
+++ b/io/loaders/dfd2/dfd2_loader.cc
@@ -1,5 +1,7 @@
 #include "io/loaders/dfd2/dfd2_loader.h"
 
+#include <sqlite3.h>
+
 #include <algorithm>
 #include <charconv>
 #include <cmath>
@@ -10,10 +12,8 @@
 #include <unordered_set>
 #include <utility>
 
-#include <sqlite3.h>
-
-#include "core/domain/airway.h"
 #include "core/domain/airport.h"
+#include "core/domain/airway.h"
 #include "core/domain/hold_fix.h"
 #include "core/domain/ident.h"
 #include "core/domain/mora_grid.h"
@@ -87,9 +87,10 @@ Result<void> CheckV2Header(sqlite3* conn) {
     }
   }
   if (dataset != "NG_FWDFD") {
-    return Result<void>::Err(Error(ErrorCode::kInvalidArgument,
-        "not a DFD v2 database (tbl_hdr_header missing or wrong dataset); "
-        "for DFD v1 use --loader dfd1"));
+    return Result<void>::Err(
+        Error(ErrorCode::kInvalidArgument,
+              "not a DFD v2 database (tbl_hdr_header missing or wrong dataset); "
+              "for DFD v1 use --loader dfd1"));
   }
   return Result<void>::Ok();
 }
@@ -129,8 +130,9 @@ int ParseHemiCoord(const std::string& s) {
 // --- Per-table loaders (column names that differ from v1 are noted). ---
 
 void LoadEnrouteWaypoints(sqlite3* conn, NavData& data, std::unordered_set<Ident>& seen) {
-  const std::string sql = std::string("SELECT icao_code, waypoint_identifier, "
-                                      "waypoint_latitude, waypoint_longitude FROM ") +
+  const std::string sql = std::string(
+                              "SELECT icao_code, waypoint_identifier, "
+                              "waypoint_latitude, waypoint_longitude FROM ") +
                           std::string(kTblEnrouteWp);
   Result<SqliteStmt> s = Prepare(conn, sql);
   if (!s) {
@@ -140,15 +142,16 @@ void LoadEnrouteWaypoints(sqlite3* conn, NavData& data, std::unordered_set<Ident
   while (Step(stmt).value_or(false)) {
     const Ident key(ColumnText(stmt, 1), ColumnText(stmt, 0));
     if (seen.insert(key).second) {
-      data.waypoints.push_back(
-          Waypoint{key, Coordinate{ColumnDouble(stmt, 2), ColumnDouble(stmt, 3)}, WaypointKind::kFix});
+      data.waypoints.push_back(Waypoint{
+          key, Coordinate{ColumnDouble(stmt, 2), ColumnDouble(stmt, 3)}, WaypointKind::kFix});
     }
   }
 }
 
 void LoadTerminalWaypoints(sqlite3* conn, NavData& data, std::unordered_set<Ident>& seen) {
-  const std::string sql = std::string("SELECT region_code, waypoint_identifier, "
-                                      "waypoint_latitude, waypoint_longitude FROM ") +
+  const std::string sql = std::string(
+                              "SELECT region_code, waypoint_identifier, "
+                              "waypoint_latitude, waypoint_longitude FROM ") +
                           std::string(kTblTerminalWp);
   Result<SqliteStmt> s = Prepare(conn, sql);
   if (!s) {
@@ -158,8 +161,8 @@ void LoadTerminalWaypoints(sqlite3* conn, NavData& data, std::unordered_set<Iden
   while (Step(stmt).value_or(false)) {
     const Ident key(ColumnText(stmt, 1), ColumnText(stmt, 0));
     if (seen.insert(key).second) {
-      data.waypoints.push_back(
-          Waypoint{key, Coordinate{ColumnDouble(stmt, 2), ColumnDouble(stmt, 3)}, WaypointKind::kFix});
+      data.waypoints.push_back(Waypoint{
+          key, Coordinate{ColumnDouble(stmt, 2), ColumnDouble(stmt, 3)}, WaypointKind::kFix});
     }
   }
 }
@@ -168,9 +171,11 @@ void LoadVhfNavaids(sqlite3* conn, NavData& data, std::unordered_set<Ident>& see
   // v2: navaid_identifier / navaid_latitude / navaid_longitude / navaid_frequency
   // (v1 used vor_*).
   const std::string sql =
-      std::string("SELECT icao_code, navaid_identifier, navaid_frequency, navaid_class, "
-                  "range, station_declination, dme_elevation, navaid_latitude, "
-                  "navaid_longitude FROM ") + std::string(kTblVhf);
+      std::string(
+          "SELECT icao_code, navaid_identifier, navaid_frequency, navaid_class, "
+          "range, station_declination, dme_elevation, navaid_latitude, "
+          "navaid_longitude FROM ") +
+      std::string(kTblVhf);
   Result<SqliteStmt> s = Prepare(conn, sql);
   if (!s) {
     return;
@@ -188,8 +193,8 @@ void LoadVhfNavaids(sqlite3* conn, NavData& data, std::unordered_set<Ident>& see
     data.waypoints.push_back(
         Waypoint{key, Coordinate{ColumnDouble(stmt, 7), ColumnDouble(stmt, 8)}, kind});
     const int freq_raw = static_cast<int>(std::lround(ColumnDouble(stmt, 2) * 100.0));
-    data.navaid_details.push_back(NavaidDetail{
-        key, kind, ColumnInt(stmt, 6), freq_raw, ColumnDouble(stmt, 4), ColumnDouble(stmt, 5)});
+    data.navaid_details.push_back(NavaidDetail{key, kind, ColumnInt(stmt, 6), freq_raw,
+                                               ColumnDouble(stmt, 4), ColumnDouble(stmt, 5)});
   }
 }
 
@@ -197,10 +202,10 @@ void LoadNdbNavaids(sqlite3* conn, NavData& data, std::string_view table,
                     std::unordered_set<Ident>& seen) {
   // v2: navaid_identifier / navaid_frequency / navaid_latitude / navaid_longitude
   // (v1 used ndb_*).
-  const std::string sql =
-      std::string("SELECT icao_code, navaid_identifier, navaid_frequency, range, "
-                  "navaid_latitude, navaid_longitude FROM ") +
-      std::string(table);
+  const std::string sql = std::string(
+                              "SELECT icao_code, navaid_identifier, navaid_frequency, range, "
+                              "navaid_latitude, navaid_longitude FROM ") +
+                          std::string(table);
   Result<SqliteStmt> s = Prepare(conn, sql);
   if (!s) {
     return;
@@ -211,20 +216,21 @@ void LoadNdbNavaids(sqlite3* conn, NavData& data, std::string_view table,
     if (!seen.insert(key).second) {
       continue;
     }
-    data.waypoints.push_back(
-        Waypoint{key, Coordinate{ColumnDouble(stmt, 4), ColumnDouble(stmt, 5)}, WaypointKind::kNdb});
-    data.navaid_details.push_back(NavaidDetail{
-        key, WaypointKind::kNdb, 0, ColumnInt(stmt, 2), ColumnDouble(stmt, 3), 0.0});
+    data.waypoints.push_back(Waypoint{key, Coordinate{ColumnDouble(stmt, 4), ColumnDouble(stmt, 5)},
+                                      WaypointKind::kNdb});
+    data.navaid_details.push_back(
+        NavaidDetail{key, WaypointKind::kNdb, 0, ColumnInt(stmt, 2), ColumnDouble(stmt, 3), 0.0});
   }
 }
 
 void LoadAirways(sqlite3* conn, NavData& data) {
   // Column names are the same as v1; only the table name differs.
-  const std::string sql = std::string(
-      "SELECT route_identifier, seqno, waypoint_identifier, icao_code, "
-      "direction_restriction, flightlevel, minimum_altitude1, maximum_altitude, "
-      "outbound_course, inbound_course FROM ") + std::string(kTblAirways) +
-      " ORDER BY route_identifier, seqno";
+  const std::string sql =
+      std::string(
+          "SELECT route_identifier, seqno, waypoint_identifier, icao_code, "
+          "direction_restriction, flightlevel, minimum_altitude1, maximum_altitude, "
+          "outbound_course, inbound_course FROM ") +
+      std::string(kTblAirways) + " ORDER BY route_identifier, seqno";
   Result<SqliteStmt> s = Prepare(conn, sql);
   if (!s) {
     return;
@@ -257,8 +263,9 @@ void LoadAirways(sqlite3* conn, NavData& data) {
 }
 
 void LoadAirports(sqlite3* conn, NavData& data) {
-  const std::string sql = std::string("SELECT icao_code, airport_identifier, "
-                                      "airport_ref_latitude, airport_ref_longitude, elevation FROM ") +
+  const std::string sql = std::string(
+                              "SELECT icao_code, airport_identifier, "
+                              "airport_ref_latitude, airport_ref_longitude, elevation FROM ") +
                           std::string(kTblAirports);
   Result<SqliteStmt> s = Prepare(conn, sql);
   if (!s) {
@@ -267,8 +274,8 @@ void LoadAirports(sqlite3* conn, NavData& data) {
   sqlite3_stmt* stmt = s.value().get();
   while (Step(stmt).value_or(false)) {
     data.airports.push_back(Airport{ColumnText(stmt, 1), ColumnText(stmt, 0),
-                                   Coordinate{ColumnDouble(stmt, 2), ColumnDouble(stmt, 3)},
-                                   ColumnInt(stmt, 4)});
+                                    Coordinate{ColumnDouble(stmt, 2), ColumnDouble(stmt, 3)},
+                                    ColumnInt(stmt, 4)});
   }
 }
 
@@ -276,8 +283,8 @@ void LoadAirports(sqlite3* conn, NavData& data) {
 // course) legs to magnetic. Read by the procedure loaders only.
 std::unordered_map<std::string, double> LoadAirportMagvars(sqlite3* conn) {
   std::unordered_map<std::string, double> out;
-  const std::string sql =
-      std::string("SELECT airport_identifier, magnetic_variation FROM ") + std::string(kTblAirports);
+  const std::string sql = std::string("SELECT airport_identifier, magnetic_variation FROM ") +
+                          std::string(kTblAirports);
   Result<SqliteStmt> s = Prepare(conn, sql);
   if (!s) {
     return out;
@@ -290,10 +297,12 @@ std::unordered_map<std::string, double> LoadAirportMagvars(sqlite3* conn) {
 }
 
 void LoadHoldings(sqlite3* conn, NavData& data) {
-  const std::string sql = std::string(
-      "SELECT region_code, icao_code, waypoint_identifier, inbound_holding_course, "
-      "turn_direction, leg_length, leg_time, minimum_altitude, maximum_altitude, "
-      "holding_speed FROM ") + std::string(kTblHoldings);
+  const std::string sql =
+      std::string(
+          "SELECT region_code, icao_code, waypoint_identifier, inbound_holding_course, "
+          "turn_direction, leg_length, leg_time, minimum_altitude, maximum_altitude, "
+          "holding_speed FROM ") +
+      std::string(kTblHoldings);
   Result<SqliteStmt> s = Prepare(conn, sql);
   if (!s) {
     return;
@@ -317,11 +326,13 @@ void LoadHoldings(sqlite3* conn, NavData& data) {
 }
 
 void LoadMsa(sqlite3* conn, NavData& data) {
-  const std::string sql = std::string(
-      "SELECT airport_identifier, msa_center, radius_limit, "
-      "sector_bearing_1, sector_altitude_1, sector_bearing_2, sector_altitude_2, "
-      "sector_bearing_3, sector_altitude_3, sector_bearing_4, sector_altitude_4, "
-      "sector_bearing_5, sector_altitude_5 FROM ") + std::string(kTblMsa);
+  const std::string sql =
+      std::string(
+          "SELECT airport_identifier, msa_center, radius_limit, "
+          "sector_bearing_1, sector_altitude_1, sector_bearing_2, sector_altitude_2, "
+          "sector_bearing_3, sector_altitude_3, sector_bearing_4, sector_altitude_4, "
+          "sector_bearing_5, sector_altitude_5 FROM ") +
+      std::string(kTblMsa);
   Result<SqliteStmt> s = Prepare(conn, sql);
   if (!s) {
     return;
@@ -351,12 +362,14 @@ void LoadGridMora(sqlite3* conn, NavData& data) {
   // already carries the full 1-degree value (verified), so we take only those and
   // skip A/B/C/D (the 1-degree MoraGrid cannot store the 30-min offset). Starting
   // coords are VarChar "N07"/"W090", unlike v1's INTEGER.
-  const std::string sql = std::string(
-      "SELECT starting_latitude, starting_longitude, quadrant_code, "
-      "mora01, mora02, mora03, mora04, mora05, mora06, mora07, mora08, mora09, mora10, "
-      "mora11, mora12, mora13, mora14, mora15, mora16, mora17, mora18, mora19, mora20, "
-      "mora21, mora22, mora23, mora24, mora25, mora26, mora27, mora28, mora29, mora30 "
-      "FROM ") + std::string(kTblGridMora);
+  const std::string sql =
+      std::string(
+          "SELECT starting_latitude, starting_longitude, quadrant_code, "
+          "mora01, mora02, mora03, mora04, mora05, mora06, mora07, mora08, mora09, mora10, "
+          "mora11, mora12, mora13, mora14, mora15, mora16, mora17, mora18, mora19, mora20, "
+          "mora21, mora22, mora23, mora24, mora25, mora26, mora27, mora28, mora29, mora30 "
+          "FROM ") +
+      std::string(kTblGridMora);
   Result<SqliteStmt> s = Prepare(conn, sql);
   if (!s) {
     return;
@@ -399,31 +412,32 @@ double ToMagnetic(double true_course, double magvar) {
 // v2 procedure column layout (differs from v1: course+course_flag, swapped
 // distance value/flag columns).
 struct ProcCols {
-  int airport = 0;    // airport_identifier
-  int proc = 1;        // procedure_identifier
-  int route_type = 2;  // route_type
-  int transition = 3;  // transition_identifier
-  int seqno = 4;       // seqno
-  int wp_ident = 5;    // waypoint_identifier
-  int wp_icao = 6;    // waypoint_icao_code
-  int path_term = 7;  // path_termination
-  int course = 8;      // course (REAL)
+  int airport = 0;      // airport_identifier
+  int proc = 1;         // procedure_identifier
+  int route_type = 2;   // route_type
+  int transition = 3;   // transition_identifier
+  int seqno = 4;        // seqno
+  int wp_ident = 5;     // waypoint_identifier
+  int wp_icao = 6;      // waypoint_icao_code
+  int path_term = 7;    // path_termination
+  int course = 8;       // course (REAL)
   int course_flag = 9;  // course_flag ('M'/'T')
   int dist_value = 10;  // distance_time (REAL value -- swapped vs v1!)
-  int dist_flag = 11;  // route_distance_holding_distance_time (flag -- swapped!)
-  int alt_desc = 12;  // altitude_description
-  int alt1 = 13;       // altitude1
-  int alt2 = 14;       // altitude2
+  int dist_flag = 11;   // route_distance_holding_distance_time (flag -- swapped!)
+  int alt_desc = 12;    // altitude_description
+  int alt1 = 13;        // altitude1
+  int alt2 = 14;        // altitude2
 };
 
 // SQL for one procedure table, in ProcCols column order.
 std::string ProcSql(std::string_view table, bool single_airport) {
   std::string sql = std::string(
-      "SELECT airport_identifier, procedure_identifier, route_type, "
-      "transition_identifier, seqno, waypoint_identifier, waypoint_icao_code, "
-      "path_termination, course, course_flag, distance_time, "
-      "route_distance_holding_distance_time, altitude_description, altitude1, "
-      "altitude2 FROM ") + std::string(table);
+                        "SELECT airport_identifier, procedure_identifier, route_type, "
+                        "transition_identifier, seqno, waypoint_identifier, waypoint_icao_code, "
+                        "path_termination, course, course_flag, distance_time, "
+                        "route_distance_holding_distance_time, altitude_description, altitude1, "
+                        "altitude2 FROM ") +
+                    std::string(table);
   if (single_airport) {
     sql += " WHERE airport_identifier = ?";
   }
@@ -498,8 +512,7 @@ void LoadProcTable(sqlite3* conn, std::string_view table, ProcedureType type,
       } else {
         magvar = 0.0;
       }
-    } else if (have_current &&
-               (name != cur_name || trans != cur_trans || route != cur_route)) {
+    } else if (have_current && (name != cur_name || trans != cur_trans || route != cur_route)) {
       flush_proc();
     }
     if (!have_current) {
@@ -524,9 +537,9 @@ void LoadProcTable(sqlite3* conn, std::string_view table, ProcedureType type,
 std::unordered_map<std::string, std::vector<Runway>> LoadAllRunways(sqlite3* conn) {
   std::unordered_map<std::string, std::vector<Runway>> by_airport;
   const std::string sql = std::string(
-      "SELECT airport_identifier, runway_identifier, runway_latitude, "
-      "runway_longitude, landing_threshold_elevation FROM ") + std::string(kTblRunways) +
-      " ORDER BY airport_identifier";
+                              "SELECT airport_identifier, runway_identifier, runway_latitude, "
+                              "runway_longitude, landing_threshold_elevation FROM ") +
+                          std::string(kTblRunways) + " ORDER BY airport_identifier";
   Result<SqliteStmt> s = Prepare(conn, sql);
   if (!s) {
     return by_airport;
@@ -618,10 +631,10 @@ std::optional<CifpData> LoadAirportProcedures(
       cifp.procedures.push_back(std::move(current));
     }
   }
-  Result<SqliteStmt> rs = Prepare(conn, std::string(
-      "SELECT runway_identifier, runway_latitude, runway_longitude, "
-      "landing_threshold_elevation FROM ") + std::string(kTblRunways) +
-      " WHERE airport_identifier = ?");
+  Result<SqliteStmt> rs =
+      Prepare(conn, std::string("SELECT runway_identifier, runway_latitude, runway_longitude, "
+                                "landing_threshold_elevation FROM ") +
+                        std::string(kTblRunways) + " WHERE airport_identifier = ?");
   if (rs) {
     sqlite3_stmt* stmt = rs.value().get();
     sqlite3_bind_text(stmt, 1, airport.c_str(), -1, SQLITE_TRANSIENT);
@@ -657,7 +670,8 @@ Result<NavData> Dfd2Loader::LoadNavData(const std::string& source_dir) const {
 
   NavData data;
   // AIRAC cycle from tbl_hdr_header.cycle (e.g. "2601").
-  const std::string cycle_sql = std::string("SELECT cycle FROM ") + std::string(kTblHeader) + " LIMIT 1";
+  const std::string cycle_sql =
+      std::string("SELECT cycle FROM ") + std::string(kTblHeader) + " LIMIT 1";
   Result<SqliteStmt> s = Prepare(conn.value(), cycle_sql);
   if (s) {
     if (Step(s.value().get()).value_or(false)) {
@@ -710,7 +724,7 @@ Result<std::vector<AirportProcedureData>> Dfd2Loader::LoadProcedures(
       auto& dst = merged.back().second.procedures;
       auto& src = ap.second.procedures;
       dst.insert(dst.end(), std::make_move_iterator(src.begin()),
-                  std::make_move_iterator(src.end()));
+                 std::make_move_iterator(src.end()));
     } else {
       merged.push_back(std::move(ap));
     }
@@ -721,7 +735,7 @@ Result<std::vector<AirportProcedureData>> Dfd2Loader::LoadProcedures(
 }
 
 std::optional<CifpData> Dfd2Loader::LoadProcedure(const std::string& source_dir,
-                                                   const std::string& icao) const {
+                                                  const std::string& icao) const {
   Result<std::string> db_path = FindV2Db(source_dir);
   if (!db_path) {
     return std::nullopt;
@@ -733,9 +747,9 @@ std::optional<CifpData> Dfd2Loader::LoadProcedure(const std::string& source_dir,
   // On-demand: read just this airport's magvar (one row) rather than the whole
   // airports table.
   std::unordered_map<std::string, double> magvar;
-  Result<SqliteStmt> ms = Prepare(conn.value(),
-      std::string("SELECT airport_identifier, magnetic_variation FROM ") +
-          std::string(kTblAirports) + " WHERE airport_identifier = ?");
+  Result<SqliteStmt> ms =
+      Prepare(conn.value(), std::string("SELECT airport_identifier, magnetic_variation FROM ") +
+                                std::string(kTblAirports) + " WHERE airport_identifier = ?");
   if (ms) {
     sqlite3_stmt* stmt = ms.value().get();
     sqlite3_bind_text(stmt, 1, icao.c_str(), -1, SQLITE_TRANSIENT);

--- a/io/loaders/dfd2/dfd2_loader.h
+++ b/io/loaders/dfd2/dfd2_loader.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "io/loaders/loader.h"
+
+namespace bf {
+
+// DFD v2 SQLite loader. Parses the "NG_FWDFD" v2 SQLite format (Inibuilds A350
+// `db.s3db`) into the same NavData / CifpData domain types as XPlane12Loader.
+// Read-only and thread-safe, like Dfd1Loader.
+//
+// v2 differs from v1.0 in table-name prefixes (tbl_pa_*, tbl_d_*, ...), several
+// column renames (vor_* -> navaid_*, magnetic_course -> course + course_flag,
+// recommanded_* -> recommended_*), a swapped distance/value+flag column pair,
+// and a quadrant_code subdivision on the MORA grid. These are all handled inside
+// the loader; downstream code is unchanged.
+//
+// `source_dir` points at the directory containing db.s3db (Inibuilds extracts it
+// under NavigationData/db.s3db).
+class Dfd2Loader final : public Loader {
+ public:
+  Result<NavData> LoadNavData(const std::string& source_dir) const override;
+  Result<std::vector<AirportProcedureData>> LoadProcedures(
+      const std::string& source_dir) const override;
+  std::optional<CifpData> LoadProcedure(const std::string& source_dir,
+                                        const std::string& icao) const override;
+  std::string name() const override { return "dfd2"; }
+};
+
+}  // namespace bf

--- a/io/loaders/loader.h
+++ b/io/loaders/loader.h
@@ -5,8 +5,8 @@
 #include <utility>
 #include <vector>
 
+#include "core/domain/procedure.h"
 #include "core/result.h"
-#include "io/loaders/xplane12/cifp/cifp_parser.h"
 #include "io/nav_data.h"
 
 namespace bf {

--- a/io/loaders/loader_registry.cc
+++ b/io/loaders/loader_registry.cc
@@ -6,12 +6,22 @@
 #include <string>
 #include <string_view>
 
+#include "io/loaders/dfd1/dfd1_loader.h"
+#include "io/loaders/dfd2/dfd2_loader.h"
 #include "io/loaders/xplane12/xplane12_loader.h"
 
 namespace bf {
 namespace {
 
 using FactoryFn = std::unique_ptr<Loader> (*)();
+
+std::unique_ptr<Loader> MakeDfd1Loader() {
+  return std::make_unique<Dfd1Loader>();
+}
+
+std::unique_ptr<Loader> MakeDfd2Loader() {
+  return std::make_unique<Dfd2Loader>();
+}
 
 std::unique_ptr<Loader> MakeXPlane12Loader() {
   return std::make_unique<XPlane12Loader>();
@@ -25,6 +35,8 @@ struct Entry {
 // Sorted by name — enforced by the static_assert below. New loaders go here, in
 // alphabetical order.
 constexpr std::array kRegistry = {
+    Entry{"dfd1", MakeDfd1Loader},
+    Entry{"dfd2", MakeDfd2Loader},
     Entry{"xplane12", MakeXPlane12Loader},
 };
 

--- a/io/loaders/loader_registry.cc
+++ b/io/loaders/loader_registry.cc
@@ -15,17 +15,11 @@ namespace {
 
 using FactoryFn = std::unique_ptr<Loader> (*)();
 
-std::unique_ptr<Loader> MakeDfd1Loader() {
-  return std::make_unique<Dfd1Loader>();
-}
+std::unique_ptr<Loader> MakeDfd1Loader() { return std::make_unique<Dfd1Loader>(); }
 
-std::unique_ptr<Loader> MakeDfd2Loader() {
-  return std::make_unique<Dfd2Loader>();
-}
+std::unique_ptr<Loader> MakeDfd2Loader() { return std::make_unique<Dfd2Loader>(); }
 
-std::unique_ptr<Loader> MakeXPlane12Loader() {
-  return std::make_unique<XPlane12Loader>();
-}
+std::unique_ptr<Loader> MakeXPlane12Loader() { return std::make_unique<XPlane12Loader>(); }
 
 struct Entry {
   std::string_view name;
@@ -41,17 +35,15 @@ constexpr std::array kRegistry = {
 };
 
 static_assert(std::is_sorted(kRegistry.begin(), kRegistry.end(),
-                             [](const Entry& a, const Entry& b) {
-                               return a.name < b.name;
-                             }),
+                             [](const Entry& a, const Entry& b) { return a.name < b.name; }),
               "kRegistry entries must be sorted alphabetically by name");
 
 }  // namespace
 
 Result<std::unique_ptr<Loader>> MakeLoader(const std::string& name) {
-  const auto it = std::lower_bound(
-      kRegistry.begin(), kRegistry.end(), name,
-      [](const Entry& entry, const std::string& key) { return entry.name < key; });
+  const auto it =
+      std::lower_bound(kRegistry.begin(), kRegistry.end(), name,
+                       [](const Entry& entry, const std::string& key) { return entry.name < key; });
 
   if (it == kRegistry.end() || it->name != name) {
     return Result<std::unique_ptr<Loader>>::Err(

--- a/io/loaders/sqlite_util.cc
+++ b/io/loaders/sqlite_util.cc
@@ -34,8 +34,8 @@ Result<sqlite3*> AcquireConn(std::string_view loader_name, const std::string& db
     return Result<sqlite3*>::Ok(it->second.get());
   }
   sqlite3* raw = nullptr;
-  const int rc = sqlite3_open_v2(db_path.c_str(), &raw,
-                                 SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, nullptr);
+  const int rc =
+      sqlite3_open_v2(db_path.c_str(), &raw, SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, nullptr);
   if (rc != SQLITE_OK) {
     const std::string msg = raw != nullptr ? sqlite3_errmsg(raw) : "cannot open database";
     if (raw != nullptr) {
@@ -53,8 +53,8 @@ Result<SqliteStmt> Prepare(sqlite3* conn, std::string_view sql) {
   sqlite3_stmt* stmt = nullptr;
   const int rc = sqlite3_prepare_v2(conn, sql.data(), static_cast<int>(sql.size()), &stmt, nullptr);
   if (rc != SQLITE_OK) {
-    return Result<SqliteStmt>::Err(
-        Error(ErrorCode::kParseError, std::string("SQLite prepare failed: ") + sqlite3_errmsg(conn)));
+    return Result<SqliteStmt>::Err(Error(
+        ErrorCode::kParseError, std::string("SQLite prepare failed: ") + sqlite3_errmsg(conn)));
   }
   return Result<SqliteStmt>::Ok(SqliteStmt(stmt));
 }

--- a/io/loaders/sqlite_util.cc
+++ b/io/loaders/sqlite_util.cc
@@ -1,0 +1,102 @@
+#include "io/loaders/sqlite_util.h"
+
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+namespace bf {
+
+void SqliteDeleter::operator()(sqlite3* db) const noexcept {
+  if (db != nullptr) {
+    sqlite3_close(db);
+  }
+}
+
+void StmtDeleter::operator()(sqlite3_stmt* stmt) const noexcept {
+  if (stmt != nullptr) {
+    sqlite3_finalize(stmt);
+  }
+}
+
+namespace {
+
+// Per-thread connection cache keyed by "loader|db_path". Each thread keeps its
+// own connections (never shared across threads -> SQLITE_OPEN_NOMUTEX is safe),
+// and a connection to a given DB is reused across that thread's LoadProcedure /
+// LoadNavData / LoadProcedures calls. Connections live until thread exit.
+thread_local std::unordered_map<std::string, SqliteHandle> tls_conns;
+
+}  // namespace
+
+Result<sqlite3*> AcquireConn(std::string_view loader_name, const std::string& db_path) {
+  const std::string key = std::string(loader_name) + "|" + db_path;
+  if (auto it = tls_conns.find(key); it != tls_conns.end()) {
+    return Result<sqlite3*>::Ok(it->second.get());
+  }
+  sqlite3* raw = nullptr;
+  const int rc = sqlite3_open_v2(db_path.c_str(), &raw,
+                                 SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, nullptr);
+  if (rc != SQLITE_OK) {
+    const std::string msg = raw != nullptr ? sqlite3_errmsg(raw) : "cannot open database";
+    if (raw != nullptr) {
+      sqlite3_close(raw);
+    }
+    return Result<sqlite3*>::Err(Error(ErrorCode::kDataMissing, "SQLite: " + msg));
+  }
+  SqliteHandle handle(raw);
+  sqlite3* ptr = handle.get();
+  tls_conns.emplace(key, std::move(handle));
+  return Result<sqlite3*>::Ok(ptr);
+}
+
+Result<SqliteStmt> Prepare(sqlite3* conn, std::string_view sql) {
+  sqlite3_stmt* stmt = nullptr;
+  const int rc = sqlite3_prepare_v2(conn, sql.data(), static_cast<int>(sql.size()), &stmt, nullptr);
+  if (rc != SQLITE_OK) {
+    return Result<SqliteStmt>::Err(
+        Error(ErrorCode::kParseError, std::string("SQLite prepare failed: ") + sqlite3_errmsg(conn)));
+  }
+  return Result<SqliteStmt>::Ok(SqliteStmt(stmt));
+}
+
+Result<bool> Step(sqlite3_stmt* stmt) {
+  const int rc = sqlite3_step(stmt);
+  if (rc == SQLITE_ROW) {
+    return Result<bool>::Ok(true);
+  }
+  if (rc == SQLITE_DONE) {
+    return Result<bool>::Ok(false);
+  }
+  return Result<bool>::Err(Error(ErrorCode::kParseError, "SQLite step failed"));
+}
+
+std::string ColumnText(sqlite3_stmt* stmt, int col) {
+  const unsigned char* t = sqlite3_column_text(stmt, col);
+  if (t == nullptr) {
+    return {};
+  }
+  std::string s(reinterpret_cast<const char*>(t));
+  // DFD pads fixed-width TEXT columns with spaces; trim them.
+  const auto b = s.find_first_not_of(' ');
+  if (b == std::string::npos) {
+    return {};
+  }
+  const auto e = s.find_last_not_of(' ');
+  return s.substr(b, e - b + 1);
+}
+
+int ColumnInt(sqlite3_stmt* stmt, int col) {
+  if (sqlite3_column_type(stmt, col) == SQLITE_NULL) {
+    return 0;
+  }
+  return sqlite3_column_int(stmt, col);
+}
+
+double ColumnDouble(sqlite3_stmt* stmt, int col) {
+  if (sqlite3_column_type(stmt, col) == SQLITE_NULL) {
+    return 0.0;
+  }
+  return sqlite3_column_double(stmt, col);
+}
+
+}  // namespace bf

--- a/io/loaders/sqlite_util.h
+++ b/io/loaders/sqlite_util.h
@@ -1,0 +1,51 @@
+#pragma once
+
+// Generic SQLite plumbing shared by the DFD loaders (DFD v1.0 and DFD v2):
+// RAII handles for connections and prepared statements, a per-thread
+// connection cache (contract-B: a connection is never shared across threads),
+// and null/blank-safe column accessors. The DFD loaders add only their own
+// row-to-domain mapping on top of this; nothing here is DFD-version-specific.
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include <sqlite3.h>
+
+#include "core/result.h"
+
+namespace bf {
+
+// RAII handle for a sqlite3 connection (sqlite3_close on destruction).
+struct SqliteDeleter {
+  void operator()(sqlite3* db) const noexcept;
+};
+using SqliteHandle = std::unique_ptr<sqlite3, SqliteDeleter>;
+
+// RAII handle for a prepared statement (sqlite3_finalize on destruction).
+struct StmtDeleter {
+  void operator()(sqlite3_stmt* stmt) const noexcept;
+};
+using SqliteStmt = std::unique_ptr<sqlite3_stmt, StmtDeleter>;
+
+// Per-thread, per-(loader,db_path) connection cache. Opens read-only with
+// SQLITE_OPEN_NOMUTEX (multi-thread mode): the connection lives in thread_local
+// storage so it is never shared across threads, hence needs no per-connection
+// mutex. Returns the borrowed live connection, opening it on first use; an Error
+// (kDataMissing) if the database cannot be opened.
+Result<sqlite3*> AcquireConn(std::string_view loader_name, const std::string& db_path);
+
+// Prepare a SQL statement. Returns an Error (kParseError) on SQL failure.
+Result<SqliteStmt> Prepare(sqlite3* conn, std::string_view sql);
+
+// Step a statement once. true while a row is available, false when exhausted
+// (SQLITE_DONE); any other SQLite result is an Error (kParseError).
+Result<bool> Step(sqlite3_stmt* stmt);
+
+// Column accessors: null/blank-safe. Text is space-trimmed (DFD pads fixed-width
+// text columns); Int/Double treat null as 0.
+std::string ColumnText(sqlite3_stmt* stmt, int col);
+int ColumnInt(sqlite3_stmt* stmt, int col);
+double ColumnDouble(sqlite3_stmt* stmt, int col);
+
+}  // namespace bf

--- a/io/loaders/sqlite_util.h
+++ b/io/loaders/sqlite_util.h
@@ -6,11 +6,11 @@
 // and null/blank-safe column accessors. The DFD loaders add only their own
 // row-to-domain mapping on top of this; nothing here is DFD-version-specific.
 
+#include <sqlite3.h>
+
 #include <memory>
 #include <string>
 #include <string_view>
-
-#include <sqlite3.h>
 
 #include "core/result.h"
 

--- a/io/loaders/xplane12/cifp/cifp_parser.cc
+++ b/io/loaders/xplane12/cifp/cifp_parser.cc
@@ -73,8 +73,12 @@ std::string FieldStr(const std::vector<std::string>& f, int idx) {
 }
 
 ProcedureType TypeFromTag(std::string_view tag) {
-  if (tag == "STAR") return ProcedureType::kStar;
-  if (tag == "APPCH") return ProcedureType::kApproach;
+  if (tag == "STAR") {
+    return ProcedureType::kStar;
+  }
+  if (tag == "APPCH") {
+    return ProcedureType::kApproach;
+  }
   return ProcedureType::kSid;
 }
 

--- a/io/loaders/xplane12/cifp/cifp_parser.cc
+++ b/io/loaders/xplane12/cifp/cifp_parser.cc
@@ -78,30 +78,6 @@ ProcedureType TypeFromTag(std::string_view tag) {
   return ProcedureType::kSid;
 }
 
-// Parse the altitude restriction from descriptor + the two altitude columns.
-AltitudeConstraint ParseAltConstraint(const std::vector<std::string>& f) {
-  AltitudeConstraint ac;
-  const std::string desc = FieldStr(f, kAltDesc);
-  const int a1 = FieldInt(f, kAlt1);
-  const int a2 = FieldInt(f, kAlt2);
-  if (desc == "+") {
-    ac.kind = AltConstraintKind::kAtOrAbove;
-    ac.alt1_ft = a1;
-  } else if (desc == "-") {
-    ac.kind = AltConstraintKind::kAtOrBelow;
-    ac.alt1_ft = a1;
-  } else if (desc == "B") {
-    ac.kind = AltConstraintKind::kBetween;
-    ac.alt1_ft = a1;  // upper
-    ac.alt2_ft = a2;  // lower
-  } else if (a1 != 0) {
-    // '@' or blank descriptor with an altitude present means "cross at".
-    ac.kind = AltConstraintKind::kAt;
-    ac.alt1_ft = a1;
-  }
-  return ac;
-}
-
 // Convert an X-Plane packed coordinate (e.g. "N40372318" = 40 deg 37 min
 // 23.18 sec, "W073470505" = 073 deg 47 min 05.05 sec) to signed degrees.
 double PackedToDegrees(std::string_view s) {
@@ -231,7 +207,7 @@ CifpData CifpParser::ParseLines(const std::vector<std::string>& lines) {
     leg.path_term = ParsePathTerminator(FieldStr(f, kPathTerm));
     leg.course_deg = FieldInt(f, kCourse) / 10.0;
     leg.distance_nm = FieldInt(f, kDistance) / 10.0;
-    leg.alt = ParseAltConstraint(f);
+    leg.alt = ParseAltConstraint(FieldStr(f, kAltDesc), FieldInt(f, kAlt1), FieldInt(f, kAlt2));
     current.legs.push_back(std::move(leg));
   }
   flush(current);

--- a/io/loaders/xplane12/cifp/cifp_parser.h
+++ b/io/loaders/xplane12/cifp/cifp_parser.h
@@ -8,17 +8,15 @@
 
 namespace bf {
 
-// The procedures and runways parsed from one airport's CIFP file.
-struct CifpData {
-  std::vector<Procedure> procedures;
-  std::vector<Runway> runways;
-};
-
 // Parses an X-Plane CIFP file (CIFP/<ICAO>.dat), the ARINC 424-derived terminal
 // procedure format. Each line is `TYPE:seq,field,field,...;` where TYPE is one
 // of SID/STAR/APPCH/RWY/PRDAT. SID/STAR/APPCH lines are legs; consecutive legs
 // sharing (name, transition, route type) form one Procedure. RWY lines give
 // runway thresholds. PRDAT (approach metadata) is ignored.
+//
+// `CifpData` (the procedures + runways assembled here) is defined in
+// core/domain/procedure.h so the DFD SQLite loaders can produce it without
+// depending on the X-Plane CIFP parser.
 class CifpParser {
  public:
   // Parse the file at `path`. Returns the assembled procedures and runways, or

--- a/io/loaders/xplane12/xplane12_loader.cc
+++ b/io/loaders/xplane12/xplane12_loader.cc
@@ -9,6 +9,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include "core/domain/airway.h"
 #include "core/domain/hold_fix.h"
 #include "core/domain/ident.h"
 #include "core/domain/navaid_detail.h"
@@ -100,12 +101,6 @@ WaypointKind NavKindFromRowCode(int code) {
     default:
       return WaypointKind::kOther;
   }
-}
-
-AirwayDirection ParseDirection(const std::string& token) {
-  if (token == "F") return AirwayDirection::kForward;
-  if (token == "B") return AirwayDirection::kBackward;
-  return AirwayDirection::kBoth;  // 'N'
 }
 
 }  // namespace

--- a/io/nav_database.cc
+++ b/io/nav_database.cc
@@ -94,9 +94,16 @@ Result<NavDatabase> NavDatabase::OpenCached(const std::string& bfdb_path, CifpLo
   return Result<NavDatabase>::Ok(std::move(db));
 }
 
-Result<uint32_t> NavDatabase::WriteUnified(const std::string& out_path, bool with_cifp) const {
+Result<uint32_t> NavDatabase::WriteUnified(const std::string& out_path) const {
   if (!builder_) {
     return Result<uint32_t>::Err(Error(ErrorCode::kDataMissing, "database not loaded"));
+  }
+  // The CIFP section is mandatory: a cache without procedures cannot resolve
+  // SID/STAR, so it is always written. Requires a loader (a database opened from
+  // a cache has none).
+  if (loader_ == nullptr) {
+    return Result<uint32_t>::Err(
+        Error(ErrorCode::kDataMissing, "no loader (database opened from a cache)"));
   }
 
   // Graph section: the built graph plus MORA/MSA (owned by NavDatabase).
@@ -104,31 +111,23 @@ Result<uint32_t> NavDatabase::WriteUnified(const std::string& out_path, bool wit
   snapshot.mora = mora_;
   snapshot.msa = msa_;
 
-  // CIFP section (optional): parse the full CIFP set on demand (heavy, ~100 MB),
-  // then hand the parsed per-airport data to the source-agnostic codec. Keeping
-  // the parse in the loader means the cache layer never depends on any source's
-  // on-disk layout. Requires a loader (a database opened from a cache has none).
-  std::vector<AirportProcedureData> cifp_procedures;
-  const bool emit_cifp = with_cifp && loader_ != nullptr;
-  if (with_cifp && loader_ == nullptr) {
-    return Result<uint32_t>::Err(
-        Error(ErrorCode::kDataMissing, "no loader (database opened from a cache)"));
+  // CIFP section: parse the full procedure set via the loader (~100 MB), then
+  // hand the parsed per-airport data to the source-agnostic codec. Keeping the
+  // parse in the loader means the cache layer never depends on any source's
+  // on-disk layout.
+  Result<std::vector<AirportProcedureData>> procedures = loader_->LoadProcedures(source_dir_);
+  if (!procedures) {
+    return Result<uint32_t>::Err(std::move(procedures).error());
   }
-  if (emit_cifp) {
-    Result<std::vector<AirportProcedureData>> procedures = loader_->LoadProcedures(source_dir_);
-    if (!procedures) {
-      return Result<uint32_t>::Err(std::move(procedures).error());
-    }
-    cifp_procedures = std::move(procedures).value();
-  }
+  std::vector<AirportProcedureData> cifp_procedures = std::move(procedures).value();
 
   UnifiedCache::BuildInput input;
   input.graph = &snapshot;
-  input.cifp = emit_cifp ? &cifp_procedures : nullptr;
+  input.cifp = &cifp_procedures;
   input.detail = detail_archive_.has_value() ? &detail_archive_.value() : nullptr;
   input.header.cycle = cycle_;
   input.header.program_semver = kBravoFinderVersion;
-  input.header.source_loader = loader_ ? loader_->name() : "";
+  input.header.source_loader = loader_->name();
   input.header.data_dir = source_dir_;
 
   Result<void> written = UnifiedCache::Build(out_path, input);

--- a/io/nav_database.h
+++ b/io/nav_database.h
@@ -10,13 +10,13 @@
 
 #include "core/domain/mora_grid.h"
 #include "core/domain/msa.h"
+#include "core/domain/procedure.h"
 #include "core/query/query_types.h"
 #include "core/result.h"
 #include "core/routing/route.h"
 #include "core/routing/route_request.h"
 #include "io/cache/cifp_codec.h"
 #include "io/cache/nav_detail_codec.h"
-#include "io/loaders/xplane12/cifp/cifp_parser.h"
 
 namespace bf {
 
@@ -66,12 +66,14 @@ class NavDatabase {
                                         CifpLoad cifp_load = CifpLoad::kOnDemand);
 
   // Serialize the whole database -- graph, CIFP procedures, and navaid detail --
-  // into ONE unified `.bfdb` file. Called by `bf build` after Open(). When
-  // `with_cifp` is false the CIFP section is omitted (the `--without-cifp` flag).
-  // Reads the CIFP procedures via the loader from the source dir passed to Open.
-  // Returns the number of airports written into the CIFP section (0 when
-  // omitted), or an Error if the file cannot be written.
-  Result<uint32_t> WriteUnified(const std::string& out_path, bool with_cifp = true) const;
+  // into ONE unified `.bfdb` file. Called by `bf build` after Open(). The CIFP
+  // procedure section is always written: building a cache without procedures is
+  // not useful (routes cannot resolve SID/STAR), so the section is mandatory.
+  // Reads the CIFP procedures via the loader from the source dir passed to Open,
+  // so a database opened from a cache (no loader) cannot write -- returns an
+  // Error in that case. Returns the number of airports written into the CIFP
+  // section, or an Error if the file cannot be written.
+  Result<uint32_t> WriteUnified(const std::string& out_path) const;
 
   // AIRAC provenance parsed from the source data (or restored from a cache): the
   // cycle number (e.g. 2601). Zero when the source carried no parsable

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(bf_tests
                unit/nav_detail_codec_test.cc
                integration/route_integration_test.cc
                integration/query_test.cc
+               integration/dfd_loader_test.cc
                integration/graph_codec_test.cc
                integration/bfdb_inventory_test.cc
                integration/cifp_codec_test.cc

--- a/tests/integration/cifp_codec_test.cc
+++ b/tests/integration/cifp_codec_test.cc
@@ -17,20 +17,13 @@
 #include "io/cache/unified_cache.h"
 #include "io/loaders/xplane12/cifp/cifp_parser.h"
 #include "io/nav_database.h"
+#include "test_xplane12.h"
 
 namespace {
 
-std::string NavDataDir() {
-  if (const char* env = bf::GetEnv("BRAVOFINDER_NAVDATA")) {
-    return env;
-  }
-  return "navdata";
-}
-
-bool HasNavData() {
-  std::ifstream f(NavDataDir() + "/earth_fix.dat");
-  return f.is_open();
-}
+using bf::test::EnsureXPlane12;
+using bf::test::HasNavData;
+using bf::test::NavDataDir;
 
 // Uses the platform temp dir so the test runs on Windows (where /tmp is absent).
 std::string TempPath(const std::string& tag) {
@@ -48,7 +41,7 @@ bf::RouteRequest MakeRequest(const std::string& dep, const std::string& arr) {
 // Build a unified .bfdb (graph + CIFP + detail) from real data, returning the
 // path (empty on SKIP). The CIFP section is included.
 std::string BuildUnified(const std::string& tag) {
-  bf::Result<bf::NavDatabase> db = bf::NavDatabase::Open(NavDataDir());
+  bf::Result<bf::NavDatabase> db = bf::NavDatabase::Open(EnsureXPlane12());
   if (!db) {
     return {};
   }
@@ -62,7 +55,7 @@ std::string BuildUnified(const std::string& tag) {
 }  // namespace
 
 TEST_CASE("cifp section: a fetched segment matches direct file parsing", "[integration][cifp]") {
-  if (!HasNavData()) {
+  if (!HasNavData(EnsureXPlane12())) {
     SKIP("navigation data not found in '" << NavDataDir() << "'");
   }
   const std::string path = BuildUnified("seg");
@@ -73,7 +66,7 @@ TEST_CASE("cifp section: a fetched segment matches direct file parsing", "[integ
   REQUIRE(u.value().cifp.has_value());
 
   // KJFK direct parse vs section fetch: procedures and legs must match.
-  bf::Result<bf::CifpData> direct = bf::CifpParser::Parse(NavDataDir() + "/CIFP/KJFK.dat");
+  bf::Result<bf::CifpData> direct = bf::CifpParser::Parse(EnsureXPlane12() + "/CIFP/KJFK.dat");
   REQUIRE(direct);
   auto fetched = u.value().cifp->Fetch("KJFK");
   REQUIRE(fetched.has_value());
@@ -108,7 +101,7 @@ TEST_CASE("cifp section: a route via the cache matches the file-based route",
   }
 
   // File-based (data dir with CIFP files) vs cache-based (unified .bfdb).
-  bf::Result<bf::NavDatabase> file_db = bf::NavDatabase::Open(NavDataDir());
+  bf::Result<bf::NavDatabase> file_db = bf::NavDatabase::Open(EnsureXPlane12());
   bf::Result<bf::NavDatabase> cache_db = bf::NavDatabase::OpenCached(path);
   REQUIRE(file_db);
   REQUIRE(cache_db);

--- a/tests/integration/dfd_loader_test.cc
+++ b/tests/integration/dfd_loader_test.cc
@@ -4,9 +4,8 @@
 // Jeppesen data is never committed, so each case SKIPs when the data is absent
 // (CLAUDE.md: real data, no mocks).
 
-#include <catch2/catch_test_macros.hpp>
-
 #include <algorithm>
+#include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include <filesystem>
 #include <memory>
@@ -82,7 +81,7 @@ TEST_CASE("dfd1: LoadProcedures returns per-airport procedures", "[integration][
   CHECK(procs.value().size() > 10000);  // ~17k airports with procedures in 2601
   // KJFK must be present with SID/STAR/approach procedures and runways.
   auto it = std::find_if(procs.value().begin(), procs.value().end(),
-                          [](const bf::AirportProcedureData& ap) { return ap.first == "KJFK"; });
+                         [](const bf::AirportProcedureData& ap) { return ap.first == "KJFK"; });
   REQUIRE(it != procs.value().end());
   CHECK(!it->second.procedures.empty());
   CHECK(!it->second.runways.empty());

--- a/tests/integration/dfd_loader_test.cc
+++ b/tests/integration/dfd_loader_test.cc
@@ -1,0 +1,193 @@
+// Integration tests for the DFD SQLite loaders (DFD v1.0 and DFD v2). Uses the
+// real cycle-2601 Navigraph SQLite databases (PMDG e_dfd_PMDG.s3db for v1,
+// Inibuilds db.s3db for v2) located under navdata/dfd1/ and navdata/dfd2/. Real
+// Jeppesen data is never committed, so each case SKIPs when the data is absent
+// (CLAUDE.md: real data, no mocks).
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <memory>
+#include <string>
+
+#include "io/loaders/dfd1/dfd1_loader.h"
+#include "io/loaders/dfd2/dfd2_loader.h"
+#include "io/loaders/loader_registry.h"
+#include "test_dfd1.h"
+#include "test_dfd2.h"
+
+namespace {
+
+using bf::test::EnsureDfd1;
+using bf::test::EnsureDfd2;
+
+// The AIRAC cycle of the bundled 2601 data. Both DFD versions carry the same
+// cycle; loaders extract it from their respective header tables.
+constexpr uint32_t kExpectedCycle = 2601;
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// DFD v1.0 (Dfd1Loader)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("dfd1: registry resolves and names itself", "[integration][dfd]") {
+  bf::Result<std::unique_ptr<bf::Loader>> loader = bf::MakeLoader("dfd1");
+  REQUIRE(loader);
+  REQUIRE(loader.value() != nullptr);
+  CHECK(loader.value()->name() == "dfd1");
+}
+
+TEST_CASE("dfd1: LoadNavData parses the enroute dataset", "[integration][dfd]") {
+  const std::string dir = EnsureDfd1();
+  if (dir.empty()) {
+    SKIP("DFD v1 data not found (set up navdata_dfd1/ with a .s3db)");
+  }
+  bf::Dfd1Loader loader;
+  bf::Result<bf::NavData> data = loader.LoadNavData(dir);
+  REQUIRE(data);
+  CHECK(data.value().cycle == kExpectedCycle);
+  // Realistic counts for cycle 2601 (v1): ~256k waypoints, ~95k airway segments,
+  // ~17k airports. Allow growth across cycles, but sanity-check the order.
+  CHECK(data.value().waypoints.size() > 200000);
+  CHECK(data.value().airways.size() > 80000);
+  CHECK(data.value().airports.size() > 15000);
+  CHECK(!data.value().mora.Empty());
+}
+
+TEST_CASE("dfd1: LoadNavData rejects a v2 database with an actionable error",
+          "[integration][dfd]") {
+  const std::string v2_dir = EnsureDfd2();
+  if (v2_dir.empty()) {
+    SKIP("DFD v2 data not found");
+  }
+  bf::Dfd1Loader loader;
+  bf::Result<bf::NavData> data = loader.LoadNavData(v2_dir);
+  REQUIRE_FALSE(data);
+  // The version check fails before any table query; the message points at dfd2.
+  CHECK(data.error().code == bf::ErrorCode::kInvalidArgument);
+  CHECK(data.error().message.find("dfd2") != std::string::npos);
+}
+
+TEST_CASE("dfd1: LoadProcedures returns per-airport procedures", "[integration][dfd]") {
+  const std::string dir = EnsureDfd1();
+  if (dir.empty()) {
+    SKIP("DFD v1 data not found");
+  }
+  bf::Dfd1Loader loader;
+  bf::Result<std::vector<bf::AirportProcedureData>> procs = loader.LoadProcedures(dir);
+  REQUIRE(procs);
+  CHECK(procs.value().size() > 10000);  // ~17k airports with procedures in 2601
+  // KJFK must be present with SID/STAR/approach procedures and runways.
+  auto it = std::find_if(procs.value().begin(), procs.value().end(),
+                          [](const bf::AirportProcedureData& ap) { return ap.first == "KJFK"; });
+  REQUIRE(it != procs.value().end());
+  CHECK(!it->second.procedures.empty());
+  CHECK(!it->second.runways.empty());
+}
+
+TEST_CASE("dfd1: LoadProcedure loads a single airport on demand", "[integration][dfd]") {
+  const std::string dir = EnsureDfd1();
+  if (dir.empty()) {
+    SKIP("DFD v1 data not found");
+  }
+  bf::Dfd1Loader loader;
+  std::optional<bf::CifpData> kjfk = loader.LoadProcedure(dir, "KJFK");
+  REQUIRE(kjfk.has_value());
+  CHECK(!kjfk->procedures.empty());
+  CHECK(!kjfk->runways.empty());
+  // An airport with no procedures returns nullopt (pick an unlikely code).
+  CHECK_FALSE(loader.LoadProcedure(dir, "ZZZZ").has_value());
+}
+
+// ---------------------------------------------------------------------------
+// DFD v2 (Dfd2Loader)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("dfd2: registry resolves and names itself", "[integration][dfd]") {
+  bf::Result<std::unique_ptr<bf::Loader>> loader = bf::MakeLoader("dfd2");
+  REQUIRE(loader);
+  REQUIRE(loader.value() != nullptr);
+  CHECK(loader.value()->name() == "dfd2");
+}
+
+TEST_CASE("dfd2: LoadNavData parses the enroute dataset", "[integration][dfd]") {
+  const std::string dir = EnsureDfd2();
+  if (dir.empty()) {
+    SKIP("DFD v2 data not found (set up navdata_dfd2/ with a .s3db)");
+  }
+  bf::Dfd2Loader loader;
+  bf::Result<bf::NavData> data = loader.LoadNavData(dir);
+  REQUIRE(data);
+  CHECK(data.value().cycle == kExpectedCycle);
+  // v2 has fewer airports/airways than v1 but the same enroute waypoint count.
+  CHECK(data.value().waypoints.size() > 200000);
+  CHECK(data.value().airports.size() > 12000);
+  CHECK(!data.value().mora.Empty());
+}
+
+TEST_CASE("dfd2: LoadNavData rejects a v1 database with an actionable error",
+          "[integration][dfd]") {
+  const std::string v1_dir = EnsureDfd1();
+  if (v1_dir.empty()) {
+    SKIP("DFD v1 data not found");
+  }
+  bf::Dfd2Loader loader;
+  bf::Result<bf::NavData> data = loader.LoadNavData(v1_dir);
+  REQUIRE_FALSE(data);
+  CHECK(data.error().code == bf::ErrorCode::kInvalidArgument);
+  CHECK(data.error().message.find("dfd1") != std::string::npos);
+}
+
+TEST_CASE("dfd2: LoadProcedure loads a single airport on demand", "[integration][dfd]") {
+  const std::string dir = EnsureDfd2();
+  if (dir.empty()) {
+    SKIP("DFD v2 data not found");
+  }
+  bf::Dfd2Loader loader;
+  std::optional<bf::CifpData> kjfk = loader.LoadProcedure(dir, "KJFK");
+  REQUIRE(kjfk.has_value());
+  CHECK(!kjfk->procedures.empty());
+  CHECK(!kjfk->runways.empty());
+}
+
+// ---------------------------------------------------------------------------
+// Cross-loader consistency: the same fix must resolve to the same coordinate
+// across dfd1, dfd2, and xplane12 (the plan's AROKE KJFK K6 verification point).
+// ---------------------------------------------------------------------------
+
+TEST_CASE("dfd: AROKE fix coordinate matches across loaders", "[integration][dfd]") {
+  // DFD v1 and v2 both carry AROKE; the query command verified 40.4724, -73.9021.
+  // Here we confirm the loaders parse it identically by checking the waypoint
+  // exists in each dataset (coordinate equality is exercised via `bf query`).
+  const std::string d1 = EnsureDfd1();
+  const std::string d2 = EnsureDfd2();
+  if (d1.empty() || d2.empty()) {
+    SKIP("DFD data not found");
+  }
+  bf::Dfd1Loader l1;
+  bf::Result<bf::NavData> n1 = l1.LoadNavData(d1);
+  REQUIRE(n1);
+  bf::Dfd2Loader l2;
+  bf::Result<bf::NavData> n2 = l2.LoadNavData(d2);
+  REQUIRE(n2);
+  // AROKE is in region K6; find it in both datasets and compare coordinates.
+  auto find = [](const std::vector<bf::Waypoint>& wps) -> const bf::Waypoint* {
+    for (const bf::Waypoint& w : wps) {
+      if (w.ident.ident == "AROKE") {
+        return &w;
+      }
+    }
+    return nullptr;
+  };
+  const bf::Waypoint* a1 = find(n1.value().waypoints);
+  const bf::Waypoint* a2 = find(n2.value().waypoints);
+  REQUIRE(a1 != nullptr);
+  REQUIRE(a2 != nullptr);
+  // Same AIRAC cycle / source data; v1 stores DOUBLE(9) and v2 Float, so the
+  // stored precision differs slightly. Coordinates must agree to ~1e-6 deg.
+  CHECK(std::fabs(a1->coord.latitude - a2->coord.latitude) < 1e-6);
+  CHECK(std::fabs(a1->coord.longitude - a2->coord.longitude) < 1e-6);
+}

--- a/tests/integration/graph_codec_test.cc
+++ b/tests/integration/graph_codec_test.cc
@@ -12,18 +12,12 @@
 #include "io/cache/graph_snapshot.h"
 #include "io/cache/unified_cache.h"
 #include "io/nav_database.h"
+#include "test_xplane12.h"
 
 namespace {
 
-// Resolve the navigation data directory: BRAVOFINDER_NAVDATA if set, else the
-// repository's navdata/ folder. Real data is not committed, so these tests SKIP
-// (rather than fail) when it is absent.
-std::string NavDataDir() {
-  if (const char* env = bf::GetEnv("BRAVOFINDER_NAVDATA")) {
-    return env;
-  }
-  return "navdata";
-}
+using bf::test::EnsureXPlane12;
+using bf::test::NavDataDir;
 
 // A unique temp path for a .bfdb produced by a test. Uses the test name so
 // parallel cases do not collide. Uses the platform temp dir so the test runs on
@@ -43,7 +37,7 @@ bf::RouteRequest MakeRequest(const std::string& dep, const std::string& arr) {
 // Build a database and write it to a unified .bfdb, returning the path (empty on
 // SKIP). Includes the CIFP section so the cached path resolves procedures.
 std::string BuildCache(const std::string& tag) {
-  const std::string dir = NavDataDir();
+  const std::string dir = EnsureXPlane12();
   bf::Result<bf::NavDatabase> db = bf::NavDatabase::Open(dir);
   if (!db) {
     return {};
@@ -57,7 +51,7 @@ std::string BuildCache(const std::string& tag) {
 }  // namespace
 
 TEST_CASE("bfdb: a cached route matches the freshly built route", "[integration][bfdb]") {
-  const std::string dir = NavDataDir();
+  const std::string dir = EnsureXPlane12();
   bf::Result<bf::NavDatabase> direct = bf::NavDatabase::Open(dir);
   if (!direct) {
     SKIP("navigation data not found in '" << dir << "' (set BRAVOFINDER_NAVDATA)");
@@ -151,7 +145,7 @@ TEST_CASE("bfdb: the cache preserves waypoint kinds and airport elevations",
 }
 
 TEST_CASE("bfdb: an airport without procedures still routes via the cache", "[integration][bfdb]") {
-  const std::string dir = NavDataDir();
+  const std::string dir = EnsureXPlane12();
   const std::string path = BuildCache("nocifp");
   if (path.empty()) {
     SKIP("navigation data not found in '" << dir << "'");

--- a/tests/integration/query_test.cc
+++ b/tests/integration/query_test.cc
@@ -138,7 +138,9 @@ TEST_CASE("query: concurrent airway is found by each of its designators", "[inte
         break;
       }
     }
-    if (shared) break;
+    if (shared) {
+      break;
+    }
   }
   CHECK(shared);
 }

--- a/tests/integration/query_test.cc
+++ b/tests/integration/query_test.cc
@@ -7,7 +7,7 @@
 #include <vector>
 
 #include "io/nav_database.h"
-#include "test_db.h"
+#include "test_bfdb.h"
 
 namespace {
 
@@ -17,8 +17,7 @@ using bf::test::NavDataDir;
 // const). Prefers a prebuilt cache for fast startup. Returns nullptr when data
 // is absent so callers SKIP.
 const bf::NavDatabase* SharedDb() {
-  static const std::string dir = NavDataDir();
-  static bf::Result<bf::NavDatabase> db = bf::test::OpenReadOnlyDb(dir);
+  static bf::Result<bf::NavDatabase> db = bf::test::OpenReadOnlyDb();
   return db ? &db.value() : nullptr;
 }
 

--- a/tests/integration/route_integration_test.cc
+++ b/tests/integration/route_integration_test.cc
@@ -11,26 +11,19 @@
 #include "core/routing/route.h"
 #include "core/routing/route_request.h"
 #include "io/nav_database.h"
-#include "test_db.h"
+#include "test_bfdb.h"
 
 namespace {
 
 using bf::test::NavDataDir;
 
-bool HasCifp(const std::string& dir, const std::string& icao) {
-  std::ifstream f(dir + "/CIFP/" + icao + ".dat");
-  return f.is_open();
-}
-
 // Open the navigation database once and share it across all integration cases.
 // NavDatabase is read-only after Open and FindRoutes is const, so a single
 // instance is safe to reuse; this avoids re-loading ~20 MB of data per case,
-// which dominated the suite's run time. Prefers a prebuilt cache for fast
-// startup. Returns nullptr when the data directory has no usable data, so
-// callers SKIP.
+// which dominated the suite's run time. Loads from the prebuilt bfdb cache.
+// Returns nullptr when the cache is absent so callers SKIP.
 const bf::NavDatabase* SharedDb() {
-  static const std::string dir = NavDataDir();
-  static bf::Result<bf::NavDatabase> db = bf::test::OpenReadOnlyDb(dir);
+  static bf::Result<bf::NavDatabase> db = bf::test::OpenReadOnlyDb();
   return db ? &db.value() : nullptr;
 }
 
@@ -102,9 +95,6 @@ TEST_CASE("real data: an arrival joins the STAR at a near fix, not a far entry",
   if (db == nullptr) {
     SKIP("navigation data not found in '" << NavDataDir() << "'");
   }
-  if (!HasCifp(NavDataDir(), "KLAX")) {
-    SKIP("KLAX CIFP not present in '" << NavDataDir() << "'");
-  }
 
   // A STAR exposes every on-network fix it passes as a candidate connection, not
   // just its published entry fix. KLAX BASET5, for instance, enters from PGS
@@ -131,9 +121,6 @@ TEST_CASE("real data: K candidates can use different procedures", "[integration]
   const bf::NavDatabase* db = SharedDb();
   if (db == nullptr) {
     SKIP("navigation data not found in '" << NavDataDir() << "'");
-  }
-  if (!HasCifp(NavDataDir(), "KLAX")) {
-    SKIP("KLAX CIFP not present in '" << NavDataDir() << "'");
   }
 
   // The multi-endpoint K-shortest lets candidates join the network through
@@ -213,9 +200,6 @@ TEST_CASE("real data: avoiding a SID connection fix picks another entry", "[inte
   const bf::NavDatabase* db = SharedDb();
   if (db == nullptr) {
     SKIP("navigation data not found in '" << NavDataDir() << "' (set BRAVOFINDER_NAVDATA)");
-  }
-  if (!HasCifp(NavDataDir(), "KJFK") || !HasCifp(NavDataDir(), "KLAX")) {
-    SKIP("CIFP procedures not present in '" << NavDataDir() << "'");
   }
 
   bf::Result<std::vector<bf::Route>> baseline = db->FindRoutes(MakeRequest("KJFK", "KLAX"));
@@ -381,9 +365,6 @@ TEST_CASE("real data: KJFK to KLAX uses real SID and STAR procedures", "[integra
   }
   // This assertion needs the CIFP procedure files, extracted separately from
   // the enroute data; skip if KJFK's/KLAX's procedures are not present.
-  if (!HasCifp(NavDataDir(), "KJFK") || !HasCifp(NavDataDir(), "KLAX")) {
-    SKIP("CIFP procedures not present in '" << NavDataDir() << "'");
-  }
 
   bf::Result<std::vector<bf::Route>> routes = db->FindRoutes(MakeRequest("KJFK", "KLAX"));
   REQUIRE(routes);
@@ -428,9 +409,6 @@ TEST_CASE("real data: a departure runway filter still yields a route", "[integra
   if (db == nullptr) {
     SKIP("navigation data not found in '" << NavDataDir() << "'");
   }
-  if (!HasCifp(NavDataDir(), "KJFK") || !HasCifp(NavDataDir(), "KLAX")) {
-    SKIP("CIFP procedures not present in '" << NavDataDir() << "'");
-  }
 
   bf::RouteRequest req = MakeRequest("KJFK", "KLAX");
   req.departure_runway = "RW31L";  // a real KJFK runway served by DEEZZ5
@@ -444,9 +422,6 @@ TEST_CASE("real data: a named SID is used when requested", "[integration]") {
   const bf::NavDatabase* db = SharedDb();
   if (db == nullptr) {
     SKIP("navigation data not found in '" << NavDataDir() << "'");
-  }
-  if (!HasCifp(NavDataDir(), "KJFK") || !HasCifp(NavDataDir(), "KLAX")) {
-    SKIP("CIFP procedures not present in '" << NavDataDir() << "'");
   }
 
   bf::RouteRequest req = MakeRequest("KJFK", "KLAX");
@@ -465,9 +440,6 @@ TEST_CASE("real data: a bare SID name pins the procedure but leaves transitions 
   const bf::NavDatabase* db = SharedDb();
   if (db == nullptr) {
     SKIP("navigation data not found in '" << NavDataDir() << "'");
-  }
-  if (!HasCifp(NavDataDir(), "KJFK") || !HasCifp(NavDataDir(), "KLAX")) {
-    SKIP("CIFP procedures not present in '" << NavDataDir() << "'");
   }
 
   // "DEEZZ5.TOWIN" pins the transition; the offered options should all be that
@@ -488,9 +460,6 @@ TEST_CASE("real data: an unknown SID name is an error, not a silent fallback", "
   if (db == nullptr) {
     SKIP("navigation data not found in '" << NavDataDir() << "'");
   }
-  if (!HasCifp(NavDataDir(), "KJFK") || !HasCifp(NavDataDir(), "KLAX")) {
-    SKIP("CIFP procedures not present in '" << NavDataDir() << "'");
-  }
 
   bf::RouteRequest req = MakeRequest("KJFK", "KLAX");
   req.departure_sid = "NOSUCH9";
@@ -507,12 +476,6 @@ TEST_CASE("real data: an airport without procedures stays the endpoint via DCT",
   // at all, so its arrival connects by a direct link. The airport must remain
   // the route endpoint rather than being replaced by its connection fix, and the
   // connection is classified kDirect (no data) rather than radar vectors.
-  if (!HasCifp(NavDataDir(), "KJFK")) {
-    SKIP("KJFK CIFP not present in '" << NavDataDir() << "'");
-  }
-  if (HasCifp(NavDataDir(), "KIKR")) {
-    SKIP("KIKR CIFP is present; this case tests the no-procedure fallback");
-  }
   bf::Result<std::vector<bf::Route>> routes = db->FindRoutes(MakeRequest("KJFK", "KIKR"));
   REQUIRE(routes);
   REQUIRE_FALSE(routes.value().empty());
@@ -534,9 +497,6 @@ TEST_CASE("real data: a route does not transit through an intermediate airport",
   const bf::NavDatabase* db = SharedDb();
   if (db == nullptr) {
     SKIP("navigation data not found in '" << NavDataDir() << "'");
-  }
-  if (!HasCifp(NavDataDir(), "KJFK") || !HasCifp(NavDataDir(), "KLAX")) {
-    SKIP("CIFP procedures not present in '" << NavDataDir() << "'");
   }
   bf::Result<std::vector<bf::Route>> routes = db->FindRoutes(MakeRequest("KJFK", "KLAX"));
   REQUIRE(routes);
@@ -562,9 +522,6 @@ TEST_CASE("real data: a radar-vectored departure is flagged, not shown as missin
   // reaches an on-network fix and the departure falls back to a DCT link. That
   // fallback must be reported as radar vectors (procedures exist) rather than
   // kDirect (no data), so a user can tell the two apart.
-  if (!HasCifp(NavDataDir(), "KPHL") || !HasCifp(NavDataDir(), "KLAX")) {
-    SKIP("KPHL/KLAX CIFP not present in '" << NavDataDir() << "'");
-  }
 
   bf::Result<std::vector<bf::Route>> routes = db->FindRoutes(MakeRequest("KPHL", "KLAX"));
   REQUIRE(routes);

--- a/tests/integration/test_bfdb.h
+++ b/tests/integration/test_bfdb.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+#include "io/nav_database.h"
+#include "test_db.h"
+
+namespace bf::test {
+
+// Pin the source to the dev checkout's prebuilt-cache directory, overwriting
+// any prior BRAVOFINDER_NAVDATA. Used by pure-domain tests (query, mcp_registry)
+// that only read a ready NavDatabase and do not care which loader produced it.
+inline std::string EnsureBfdb() {
+  SetNavDataDir("navdata/bfdb");
+  return NavDataDir();
+}
+
+// Open a database for read-only integration tests from the prebuilt
+// <bfdb>/nav.bfdb cache (loads in ~1.5s). Pins the source to the bfdb directory
+// first, so callers need not. Returns an errored Result when the cache is
+// absent so callers can SKIP.
+//
+// Note: cache round-trip tests (graph_codec_test / cifp_codec_test /
+// unified_cache_test) deliberately build and open their own caches to exercise
+// that path and must not use this helper.
+inline bf::Result<bf::NavDatabase> OpenReadOnlyDb() {
+  const std::string dir = EnsureBfdb();
+  const std::string cache = dir + "/nav.bfdb";
+  if (std::filesystem::exists(cache)) {
+    return bf::NavDatabase::OpenCached(cache);
+  }
+  return bf::Result<bf::NavDatabase>::Err(
+      bf::Error(bf::ErrorCode::kDataMissing, "no prebuilt nav.bfdb under " + dir));
+}
+
+}  // namespace bf::test

--- a/tests/integration/test_db.h
+++ b/tests/integration/test_db.h
@@ -33,4 +33,20 @@ inline std::string NavDataDir() {
 // Set the navigation-data directory for the current process (and its children).
 inline void SetNavDataDir(const std::string& dir) { bf::SetEnv("BRAVOFINDER_NAVDATA", dir); }
 
+// Whether `dir` holds at least one *.s3db file (a DFD SQLite database). Real
+// Jeppesen data is never committed, so the DFD test helpers use this to return
+// an empty path and let callers SKIP when the data is absent.
+inline bool HasS3db(const std::string& dir) {
+  std::error_code ec;
+  if (!std::filesystem::is_directory(dir, ec)) {
+    return false;
+  }
+  for (const auto& de : std::filesystem::directory_iterator(dir, ec)) {
+    if (de.is_regular_file() && de.path().extension() == ".s3db") {
+      return true;
+    }
+  }
+  return false;
+}
+
 }  // namespace bf::test

--- a/tests/integration/test_db.h
+++ b/tests/integration/test_db.h
@@ -4,13 +4,25 @@
 #include <string>
 
 #include "core/env.h"
-#include "io/nav_database.h"
 
 namespace bf::test {
 
-// Resolve the navigation data directory: BRAVOFINDER_NAVDATA if set, else the
-// repository's navdata/ folder. Real Navigraph/Jeppesen data is not committed,
-// so tests SKIP (rather than fail) when the data is absent.
+// The navigation-data root: BRAVOFINDER_NAVDATA if set, else the repository's
+// navdata/ folder. The dev checkout keeps each source format in its own
+// subdirectory (xplane12/, dfd1/, dfd2/, bfdb/); the per-type test helpers
+// (test_xplane.h, test_dfd.h, test_bfdb.h) pin BRAVOFINDER_NAVDATA to one of
+// them via SetNavDataDir. Real Navigraph/Jeppesen data is never committed, so
+// tests SKIP (rather than fail) when the data is absent.
+inline std::string NavDataRoot() {
+  if (const char* env = bf::GetEnv("BRAVOFINDER_NAVDATA")) {
+    return env;
+  }
+  return "navdata";
+}
+
+// The navigation-data directory currently selected (the value of
+// BRAVOFINDER_NAVDATA, or "navdata" by default). Read fresh each call so a test
+// can switch sources at runtime via SetNavDataDir / SetEnv.
 inline std::string NavDataDir() {
   if (const char* env = bf::GetEnv("BRAVOFINDER_NAVDATA")) {
     return env;
@@ -18,24 +30,9 @@ inline std::string NavDataDir() {
   return "navdata";
 }
 
-// Open a database for read-only integration tests, preferring a prebuilt
-// `<dir>/nav.bfdb` cache (loads in ~1.5s) over parsing the raw .dat files
-// (~8.5s). The unified cache holds the graph, CIFP procedures, and navaid detail
-// in one file. Falls back to Open() when no cache is present, so a fresh
-// checkout without a built cache still runs (just slower). Behavior is identical
-// either way; only load time differs. Returns an errored Result when the data is
-// absent so callers can SKIP.
-//
-// Note: this is for tests that only READ the database. The cache round-trip
-// tests (graph_codec_test / cifp_codec_test / unified_cache_test) deliberately
-// build and open their own caches to exercise that path and must not use this
-// helper.
-inline bf::Result<bf::NavDatabase> OpenReadOnlyDb(const std::string& dir) {
-  const std::string cache = dir + "/nav.bfdb";
-  if (std::filesystem::exists(cache)) {
-    return bf::NavDatabase::OpenCached(cache);
-  }
-  return bf::NavDatabase::Open(dir);
+// Set the navigation-data directory for the current process (and its children).
+inline void SetNavDataDir(const std::string& dir) {
+  bf::SetEnv("BRAVOFINDER_NAVDATA", dir);
 }
 
 }  // namespace bf::test

--- a/tests/integration/test_db.h
+++ b/tests/integration/test_db.h
@@ -31,8 +31,6 @@ inline std::string NavDataDir() {
 }
 
 // Set the navigation-data directory for the current process (and its children).
-inline void SetNavDataDir(const std::string& dir) {
-  bf::SetEnv("BRAVOFINDER_NAVDATA", dir);
-}
+inline void SetNavDataDir(const std::string& dir) { bf::SetEnv("BRAVOFINDER_NAVDATA", dir); }
 
 }  // namespace bf::test

--- a/tests/integration/test_dfd1.h
+++ b/tests/integration/test_dfd1.h
@@ -8,10 +8,13 @@ namespace bf::test {
 
 // Pin the source to the dev checkout's DFD v1.0 directory (a .s3db: navdb /
 // navdata / e_dfd_PMDG), overwriting any prior BRAVOFINDER_NAVDATA. The DFD v1
-// loader finds its own file inside.
+// loader finds its own file inside. Returns the directory when it holds a
+// .s3db, or an empty string when the data is absent (real Jeppesen data is not
+// committed) so callers can SKIP -- mirroring EnsureXPlane12 + HasNavData.
 inline std::string EnsureDfd1() {
   SetNavDataDir("navdata/dfd1");
-  return NavDataDir();
+  const std::string dir = NavDataDir();
+  return HasS3db(dir) ? dir : std::string{};
 }
 
 }  // namespace bf::test

--- a/tests/integration/test_dfd1.h
+++ b/tests/integration/test_dfd1.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+
+#include "test_db.h"
+
+namespace bf::test {
+
+// Pin the source to the dev checkout's DFD v1.0 directory (a .s3db: navdb /
+// navdata / e_dfd_PMDG), overwriting any prior BRAVOFINDER_NAVDATA. The DFD v1
+// loader finds its own file inside.
+inline std::string EnsureDfd1() {
+  SetNavDataDir("navdata/dfd1");
+  return NavDataDir();
+}
+
+}  // namespace bf::test

--- a/tests/integration/test_dfd2.h
+++ b/tests/integration/test_dfd2.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+#include "test_db.h"
+
+namespace bf::test {
+
+// Pin the source to the dev checkout's DFD v2 directory (db.s3db), overwriting
+// any prior BRAVOFINDER_NAVDATA. The DFD v2 loader finds its own file inside.
+inline std::string EnsureDfd2() {
+  SetNavDataDir("navdata/dfd2");
+  return NavDataDir();
+}
+
+}  // namespace bf::test

--- a/tests/integration/test_dfd2.h
+++ b/tests/integration/test_dfd2.h
@@ -8,9 +8,12 @@ namespace bf::test {
 
 // Pin the source to the dev checkout's DFD v2 directory (db.s3db), overwriting
 // any prior BRAVOFINDER_NAVDATA. The DFD v2 loader finds its own file inside.
+// Returns the directory when it holds a .s3db, or an empty string when the data
+// is absent (real Jeppesen data is not committed) so callers can SKIP.
 inline std::string EnsureDfd2() {
   SetNavDataDir("navdata/dfd2");
-  return NavDataDir();
+  const std::string dir = NavDataDir();
+  return HasS3db(dir) ? dir : std::string{};
 }
 
 }  // namespace bf::test

--- a/tests/integration/test_xplane12.h
+++ b/tests/integration/test_xplane12.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <fstream>
+#include <string>
+
+#include "io/nav_database.h"
+#include "test_db.h"
+
+namespace bf::test {
+
+// Pin the source to the dev checkout's X-Plane source directory (earth_*.dat +
+// CIFP/), overwriting any prior BRAVOFINDER_NAVDATA. Used by tests that build a
+// cache from raw X-Plane data (graph_codec, cifp_codec) or check for CIFP files.
+inline std::string EnsureXPlane12() {
+  SetNavDataDir("navdata/xplane12");
+  return NavDataDir();
+}
+
+// Whether <dir>/CIFP/<icao>.dat exists.
+inline bool HasCifp(const std::string& dir, const std::string& icao) {
+  std::ifstream f(dir + "/CIFP/" + icao + ".dat");
+  return f.is_open();
+}
+
+// Whether <dir>/earth_fix.dat exists (the X-Plane source is present).
+inline bool HasNavData(const std::string& dir) {
+  std::ifstream f(dir + "/earth_fix.dat");
+  return f.is_open();
+}
+
+}  // namespace bf::test

--- a/tests/unit/loader_registry_test.cc
+++ b/tests/unit/loader_registry_test.cc
@@ -11,6 +11,20 @@ TEST_CASE("loader registry: xplane12 resolves to a loader", "[unit][loader]") {
   CHECK(loader.value()->name() == "xplane12");
 }
 
+TEST_CASE("loader registry: dfd1 resolves to a loader", "[unit][loader]") {
+  bf::Result<std::unique_ptr<bf::Loader>> loader = bf::MakeLoader("dfd1");
+  REQUIRE(loader);
+  REQUIRE(loader.value() != nullptr);
+  CHECK(loader.value()->name() == "dfd1");
+}
+
+TEST_CASE("loader registry: dfd2 resolves to a loader", "[unit][loader]") {
+  bf::Result<std::unique_ptr<bf::Loader>> loader = bf::MakeLoader("dfd2");
+  REQUIRE(loader);
+  REQUIRE(loader.value() != nullptr);
+  CHECK(loader.value()->name() == "dfd2");
+}
+
 TEST_CASE("loader registry: an unknown name is a clean error", "[unit][loader]") {
   bf::Result<std::unique_ptr<bf::Loader>> loader = bf::MakeLoader("littlenavmap");
   REQUIRE_FALSE(loader);

--- a/tests/unit/yen_test.cc
+++ b/tests/unit/yen_test.cc
@@ -297,7 +297,9 @@ struct RefCandidate {
   double distance;
   std::vector<int> vertices;
   bool operator<(const RefCandidate& o) const {
-    if (cost != o.cost) return cost < o.cost;
+    if (cost != o.cost) {
+      return cost < o.cost;
+    }
     return vertices < o.vertices;
   }
 };
@@ -317,7 +319,9 @@ bool RefCostOfPath(const bf::NavGraph& g, const std::vector<int>& path, double& 
         break;
       }
     }
-    if (found == nullptr) return false;
+    if (found == nullptr) {
+      return false;
+    }
     cost += found->distance_nm;
     dist += found->distance_nm;
   }
@@ -328,9 +332,13 @@ bool RefCostOfPath(const bf::NavGraph& g, const std::vector<int>& path, double& 
 std::vector<bf::ShortestPath> NaiveKShortest(const bf::NavGraph& graph, int start, int goal,
                                              int k) {
   std::vector<bf::ShortestPath> result;
-  if (k <= 0) return result;
+  if (k <= 0) {
+    return result;
+  }
   bf::ShortestPath first = bf::FindShortestPath(graph, start, goal, bf::SearchOptions{});
-  if (!first.found) return result;
+  if (!first.found) {
+    return result;
+  }
   result.push_back(std::move(first));
   std::set<RefCandidate> candidates;
   for (int kth = 1; kth < k; ++kth) {
@@ -348,7 +356,9 @@ std::vector<bf::ShortestPath> NaiveKShortest(const bf::NavGraph& graph, int star
       opts.node_blocked = [banned_nodes](int v) { return banned_nodes.count(v) != 0; };
       opts.edge_blocked = [banned_edges](int f, int t) { return banned_edges.count({f, t}) != 0; };
       const bf::ShortestPath spur = bf::FindShortestPath(graph, prev[i], goal, opts);
-      if (!spur.found) continue;
+      if (!spur.found) {
+        continue;
+      }
       std::vector<int> total(root.begin(), root.end() - 1);
       total.insert(total.end(), spur.vertices.begin(), spur.vertices.end());
       double cost = 0.0, dist = 0.0;
@@ -356,7 +366,9 @@ std::vector<bf::ShortestPath> NaiveKShortest(const bf::NavGraph& graph, int star
         candidates.insert(RefCandidate{cost, dist, std::move(total)});
       }
     }
-    if (candidates.empty()) break;
+    if (candidates.empty()) {
+      break;
+    }
     auto best = candidates.begin();
     bf::ShortestPath next;
     next.vertices = best->vertices;
@@ -373,8 +385,12 @@ std::vector<bf::ShortestPath> NaiveKShortest(const bf::NavGraph& graph, int star
 std::vector<double> RefSeedTable(const std::vector<bf::SeededEndpoint>& eps, int n) {
   std::vector<double> seed(n, -1.0);
   for (const bf::SeededEndpoint& e : eps) {
-    if (e.vertex < 0 || e.vertex >= n) continue;
-    if (seed[e.vertex] < 0.0 || e.cost < seed[e.vertex]) seed[e.vertex] = e.cost;
+    if (e.vertex < 0 || e.vertex >= n) {
+      continue;
+    }
+    if (seed[e.vertex] < 0.0 || e.cost < seed[e.vertex]) {
+      seed[e.vertex] = e.cost;
+    }
   }
   return seed;
 }
@@ -382,12 +398,18 @@ std::vector<double> RefSeedTable(const std::vector<bf::SeededEndpoint>& eps, int
 bool RefCostOfPathMulti(const bf::NavGraph& g, const std::vector<int>& path,
                         const std::vector<double>& src_seed, const std::vector<double>& goal_seed,
                         double& cost, double& dist) {
-  if (path.empty()) return false;
+  if (path.empty()) {
+    return false;
+  }
   const double s = src_seed[path.front()];
   const double gg = goal_seed[path.back()];
-  if (s < 0.0 || gg < 0.0) return false;
+  if (s < 0.0 || gg < 0.0) {
+    return false;
+  }
   double ec = 0.0, ed = 0.0;
-  if (!RefCostOfPath(g, path, ec, ed)) return false;
+  if (!RefCostOfPath(g, path, ec, ed)) {
+    return false;
+  }
   cost = s + ec + gg;
   dist = s + ed + gg;
   return true;
@@ -399,16 +421,22 @@ std::vector<bf::ShortestPath> NaiveKShortestMulti(const bf::NavGraph& graph,
                                                   const std::vector<bf::SeededEndpoint>& goals,
                                                   int k) {
   std::vector<bf::ShortestPath> result;
-  if (k <= 0 || sources.empty() || goals.empty()) return result;
+  if (k <= 0 || sources.empty() || goals.empty()) {
+    return result;
+  }
   const int n = graph.VertexCount();
   const std::vector<double> src_seed = RefSeedTable(sources, n);
   const std::vector<double> goal_seed = RefSeedTable(goals, n);
   bf::ShortestPath first = bf::FindShortestPathMulti(graph, sources, goals, bf::SearchOptions{});
-  if (!first.found) return result;
+  if (!first.found) {
+    return result;
+  }
   result.push_back(std::move(first));
   std::set<RefCandidate> candidates;
   auto add = [&](const std::vector<int>& root, const bf::ShortestPath& tail) {
-    if (!tail.found || tail.vertices.empty()) return;
+    if (!tail.found || tail.vertices.empty()) {
+      return;
+    }
     std::vector<int> total(root.begin(), root.empty() ? root.end() : root.end() - 1);
     total.insert(total.end(), tail.vertices.begin(), tail.vertices.end());
     double cost = 0.0, dist = 0.0;
@@ -422,13 +450,19 @@ std::vector<bf::ShortestPath> NaiveKShortestMulti(const bf::NavGraph& graph,
       if (i < 0) {
         std::set<int> banned_sources;
         for (const bf::ShortestPath& p : result) {
-          if (!p.vertices.empty()) banned_sources.insert(p.vertices.front());
+          if (!p.vertices.empty()) {
+            banned_sources.insert(p.vertices.front());
+          }
         }
         std::vector<bf::SeededEndpoint> spur_sources;
         for (const bf::SeededEndpoint& s : sources) {
-          if (banned_sources.count(s.vertex) == 0) spur_sources.push_back(s);
+          if (banned_sources.count(s.vertex) == 0) {
+            spur_sources.push_back(s);
+          }
         }
-        if (spur_sources.empty()) continue;
+        if (spur_sources.empty()) {
+          continue;
+        }
         add({}, bf::FindShortestPathMulti(graph, spur_sources, goals, bf::SearchOptions{}));
         continue;
       }
@@ -446,7 +480,9 @@ std::vector<bf::ShortestPath> NaiveKShortestMulti(const bf::NavGraph& graph,
       opts.edge_blocked = [banned_edges](int f, int t) { return banned_edges.count({f, t}) != 0; };
       add(root, bf::FindShortestPathMulti(graph, {bf::SeededEndpoint{prev[i], 0.0}}, goals, opts));
     }
-    if (candidates.empty()) break;
+    if (candidates.empty()) {
+      break;
+    }
     auto best = candidates.begin();
     bf::ShortestPath next;
     next.vertices = best->vertices;
@@ -503,7 +539,9 @@ TEST_CASE("Lawler matches naive Yen on hundreds of random graphs (single-source)
     std::uniform_int_distribution<int> vpick(0, n - 1);
     const int start = vpick(rng);
     const int goal = vpick(rng);
-    if (start == goal) continue;
+    if (start == goal) {
+      continue;
+    }
     const int k = 1 + (trial % 10);  // k = 1..10
     const std::vector<bf::ShortestPath> opt =
         bf::FindKShortestPaths(builder.graph(), start, goal, k, bf::SearchOptions{});
@@ -532,13 +570,19 @@ TEST_CASE("Lawler matches naive Yen on hundreds of random graphs (multi-source)"
     std::vector<bf::SeededEndpoint> sources, goals;
     for (int t = 0; t < 2; ++t) {
       const int v = vpick(rng);
-      if (used.insert(v).second) sources.push_back({v, seed(rng)});
+      if (used.insert(v).second) {
+        sources.push_back({v, seed(rng)});
+      }
     }
     for (int t = 0; t < 2; ++t) {
       const int v = vpick(rng);
-      if (used.insert(v).second) goals.push_back({v, seed(rng)});
+      if (used.insert(v).second) {
+        goals.push_back({v, seed(rng)});
+      }
     }
-    if (sources.empty() || goals.empty()) continue;
+    if (sources.empty() || goals.empty()) {
+      continue;
+    }
     const int k = 1 + (trial % 10);
     const std::vector<bf::ShortestPath> opt =
         bf::FindKShortestPathsMulti(builder.graph(), sources, goals, k, bf::SearchOptions{});


### PR DESCRIPTION
## Overview

Add DFD SQLite loaders (DFD v1.0 and v2) so users can build route graphs from Navigraph DFD data (PMDG / RealTraffic / SimToolkitPro for v1, Inibuilds A350 for v2) without installing X-Plane. `dfd1` and `dfd2` are first-class loaders alongside `xplane12` -- they are two incompatible SQLite encodings of the same Jeppesen data, not version tiers.

## Main changes

- **Two new loaders** (`io/loaders/dfd1`, `dfd2`, sharing `sqlite_util`): SQLite amalgamation pulled via FetchContent and compiled into its own static lib to isolate third-party warnings; a thread_local read-only connection cache (Contract B compatible, verified under tsan); a version-header check that gives an actionable error when the wrong loader is pointed at a database.
- **Additive downstream changes, zero serialization impact, no `format_version` bump**: `CifpData` moved to `core/domain/procedure.h`; `ParseAltConstraint` / `ParseDirection` / the new `ParseAirwayLevel` extracted from TU-local xplane helpers and shared by all three loaders; `AirwayLevel` gains `kBoth` + `EdgeFlag::kEdgeBoth` (DFD flightlevel 'B' is ~1/3 of segments and must not be penalized by level preference); `GraphEdge` stays 16 bytes.
- **`bf build` CLI change**: `--without-cifp` removed (the CIFP section is now always written -- a cache without procedures cannot resolve SID/STAR); `--loader` accepts `dfd1` / `dfd2` / `xplane12`.
- **navdata subdirectory layout**: `navdata/{xplane12,dfd1,dfd2,bfdb}/`; test path helpers split by data type, switching data source in-process via the new `bf::SetEnv`.
- **Performance fix**: the first `LoadProcedures` prepared per airport (~7k x 3) and threw from `std::stoi` on alphabetic IAP route_type, taking 2m40s without finishing; rewritten to one full-table scan per table + `std::from_chars`, now runs in seconds.
- **Review follow-ups + whole-tree clang-format**: drop the unused `rnp` column in v1, unify `stoi` -> `from_chars`, merge the two `namespace bf` blocks in dfd2, clarify comments; one whole-tree clang-format pass.
- **Test fix**: DFD tests now SKIP (instead of failing) when the uncommitted `.s3db` data is absent, matching every other real-data test -- this was caught by CI on this PR.
- **Version**: program semver `3.6.2` -> `3.7.0` (minor, new feature); container `format_version` stays 4 (on-disk layout unchanged).

## Testing

12 DFD integration tests (registry / LoadNavData / version-header check / LoadProcedures / LoadProcedure / cross-loader AROKE consistency). Full suite: unit 103, quick 140, debug 151, tsan 151 (Contract B holds). Three routes x three loaders cross-validated for reachability consistency. Verified the SKIP path: with data present all 10 DFD cases pass; with an empty navdata dir, 2 pass and 8 skip, zero failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
