### PR TITLE
Fixes #27: read the Fenix AIRAC cycle from the CycleName config key

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(APPLE)
 endif()
 
 project(BravoFinder
-        VERSION 3.23.2
+        VERSION 3.23.3
         DESCRIPTION "A realistic and compliant flight routing engine and its query tools"
         LANGUAGES C CXX)
 

--- a/libs/engine/io/loaders/fenix/fenix_loader.cc
+++ b/libs/engine/io/loaders/fenix/fenix_loader.cc
@@ -197,7 +197,7 @@ AltitudeConstraint ParseFenixAlt(const std::string& alt_text) {
 // ---- cycle extraction ---------------------------------------------------
 
 uint32_t ParseFenixCycle(sqlite3* conn) {
-  Result<SqliteStmt> stmt = Prepare(conn, "SELECT val FROM config WHERE key='Cycle'");
+  Result<SqliteStmt> stmt = Prepare(conn, "SELECT val FROM config WHERE key='CycleName'");
   if (!stmt) {
     return 0;
   }


### PR DESCRIPTION
### Problem
`bf build --loader fenix` writes `nav.bfdb` (cycle=0) instead of `nav_<cycle>.bfdb`, so multi-cycle deployments (`?cycle=` / `list_cycles`) can't address Fenix caches.

### Root cause
`ParseFenixCycle` queries `config WHERE key='Cycle'`, but the Fenix schema only has `CycleName` / `CycleStartDate` / `CycleEndDate` — the query always matches zero rows.

### Fix
Query `CycleName` instead (one-line change). `std::from_chars` parses `2607n1` → `2607`. `format_version` stays 16: read-side fix, no layout change, and old cycle=0 caches retire automatically via the filename change, so no poison bump.

### Verification
- Customized 2607n1 source: builds `nav_2607.bfdb`, header `cycle=2607`.
- Jeppesen 2607 source: builds `nav_2607.bfdb`, header `cycle=2607`.
- Full debug suite: 305/305 pass.

### Version
PATCH 3.23.2 → 3.23.3 (3.23.2 already taken by c5ec45e on v3).
